### PR TITLE
set repo/owner in different fields for webhookinfo

### DIFF
--- a/vcsutils/webhookparser/bitbucketcloud.go
+++ b/vcsutils/webhookparser/bitbucketcloud.go
@@ -57,7 +57,7 @@ func (webhook *BitbucketCloudWebhook) parseIncomingWebhook(payload []byte) (*Web
 func (webhook *BitbucketCloudWebhook) parsePushEvent(bitbucketCloudWebHook *bitbucketCloudWebHook) *WebhookInfo {
 	return &WebhookInfo{
 		TargetRepositoryDetails: webhook.parseRepoFullName(bitbucketCloudWebHook.Repository.FullName),
-		Branch:                  bitbucketCloudWebHook.Push.Changes[0].New.Name,
+		TargetBranch:            bitbucketCloudWebHook.Push.Changes[0].New.Name,
 		Timestamp:               bitbucketCloudWebHook.Push.Changes[0].New.Target.Date.UTC().Unix(),
 		Event:                   vcsutils.Push,
 	}
@@ -67,7 +67,7 @@ func (webhook *BitbucketCloudWebhook) parsePrEvents(bitbucketCloudWebHook *bitbu
 	return &WebhookInfo{
 		PullRequestId:           bitbucketCloudWebHook.PullRequest.Id,
 		TargetRepositoryDetails: webhook.parseRepoFullName(bitbucketCloudWebHook.PullRequest.Destination.Repository.FullName),
-		Branch:                  bitbucketCloudWebHook.PullRequest.Destination.Branch.Name,
+		TargetBranch:            bitbucketCloudWebHook.PullRequest.Destination.Branch.Name,
 		SourceRepositoryDetails: webhook.parseRepoFullName(bitbucketCloudWebHook.PullRequest.Source.Repository.FullName),
 		SourceBranch:            bitbucketCloudWebHook.PullRequest.Source.Branch.Name,
 		Timestamp:               bitbucketCloudWebHook.PullRequest.UpdatedOn.UTC().Unix(),

--- a/vcsutils/webhookparser/bitbucketcloud_test.go
+++ b/vcsutils/webhookparser/bitbucketcloud_test.go
@@ -33,7 +33,7 @@ func TestBitbucketCloudParseIncomingPushWebhook(t *testing.T) {
 	// Check values
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, bitbucketCloudPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
 }
@@ -55,7 +55,7 @@ func TestBitbucketCloudParseIncomingPrCreateWebhook(t *testing.T) {
 	assert.Equal(t, bitbucketCloudExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, bitbucketCloudPrCreateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
@@ -80,7 +80,7 @@ func TestBitbucketCloudParseIncomingPrUpdateWebhook(t *testing.T) {
 	assert.Equal(t, bitbucketCloudExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, bitbucketCloudPrUpdateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)

--- a/vcsutils/webhookparser/bitbucketcloud_test.go
+++ b/vcsutils/webhookparser/bitbucketcloud_test.go
@@ -31,7 +31,8 @@ func TestBitbucketCloudParseIncomingPushWebhook(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check values
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, bitbucketCloudPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
@@ -52,10 +53,12 @@ func TestBitbucketCloudParseIncomingPrCreateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, bitbucketCloudExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, bitbucketCloudPrCreateExpectedTime, actual.Timestamp)
-	assert.Equal(t, expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrCreated, actual.Event)
 }
@@ -75,10 +78,12 @@ func TestBitbucketCloudParseIncomingPrUpdateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, bitbucketCloudExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, bitbucketCloudPrUpdateExpectedTime, actual.Timestamp)
-	assert.Equal(t, expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrEdited, actual.Event)
 }

--- a/vcsutils/webhookparser/bitbucketserver.go
+++ b/vcsutils/webhookparser/bitbucketserver.go
@@ -77,7 +77,7 @@ func (webhook *BitbucketServerWebhook) parsePushEvent(bitbucketCloudWebHook *bit
 	repository := bitbucketCloudWebHook.Repository
 	return &WebhookInfo{
 		TargetRepositoryDetails: webhook.getRepositoryDetails(repository),
-		Branch:                  strings.TrimPrefix(bitbucketCloudWebHook.Changes[0].RefId, "refs/heads/"),
+		TargetBranch:            strings.TrimPrefix(bitbucketCloudWebHook.Changes[0].RefId, "refs/heads/"),
 		Timestamp:               eventTime.UTC().Unix(),
 		Event:                   vcsutils.Push,
 	}, nil
@@ -98,7 +98,7 @@ func (webhook *BitbucketServerWebhook) parsePrEvents(bitbucketCloudWebHook *bitb
 	return &WebhookInfo{
 		PullRequestId:           bitbucketCloudWebHook.PullRequest.ID,
 		TargetRepositoryDetails: webhook.getRepositoryDetails(bitbucketCloudWebHook.PullRequest.ToRef.Repository),
-		Branch:                  strings.TrimPrefix(bitbucketCloudWebHook.PullRequest.ToRef.ID, "refs/heads/"),
+		TargetBranch:            strings.TrimPrefix(bitbucketCloudWebHook.PullRequest.ToRef.ID, "refs/heads/"),
 		SourceRepositoryDetails: webhook.getRepositoryDetails(bitbucketCloudWebHook.PullRequest.FromRef.Repository),
 		SourceBranch:            strings.TrimPrefix(bitbucketCloudWebHook.PullRequest.FromRef.ID, "refs/heads/"),
 		Timestamp:               eventTime.UTC().Unix(),

--- a/vcsutils/webhookparser/bitbucketserver.go
+++ b/vcsutils/webhookparser/bitbucketserver.go
@@ -74,12 +74,20 @@ func (webhook *BitbucketServerWebhook) parsePushEvent(bitbucketCloudWebHook *bit
 	if err != nil {
 		return nil, err
 	}
+	repository := bitbucketCloudWebHook.Repository
 	return &WebhookInfo{
-		Repository: getFullRepositoryName(bitbucketCloudWebHook.Repository),
-		Branch:     strings.TrimPrefix(bitbucketCloudWebHook.Changes[0].RefId, "refs/heads/"),
-		Timestamp:  eventTime.UTC().Unix(),
-		Event:      vcsutils.Push,
+		TargetRepositoryDetails: webhook.getRepositoryDetails(repository),
+		Branch:                  strings.TrimPrefix(bitbucketCloudWebHook.Changes[0].RefId, "refs/heads/"),
+		Timestamp:               eventTime.UTC().Unix(),
+		Event:                   vcsutils.Push,
 	}, nil
+}
+
+func (webhook *BitbucketServerWebhook) getRepositoryDetails(repository bitbucketv1.Repository) WebHookInfoRepoDetails {
+	return WebHookInfoRepoDetails{
+		Name:  repository.Slug,
+		Owner: strings.TrimPrefix(strings.ToLower(repository.Project.Key), "~"),
+	}
 }
 
 func (webhook *BitbucketServerWebhook) parsePrEvents(bitbucketCloudWebHook *bitbucketServerWebHook, event vcsutils.WebhookEvent) (*WebhookInfo, error) {
@@ -88,13 +96,13 @@ func (webhook *BitbucketServerWebhook) parsePrEvents(bitbucketCloudWebHook *bitb
 		return nil, err
 	}
 	return &WebhookInfo{
-		PullRequestId:    bitbucketCloudWebHook.PullRequest.ID,
-		Repository:       getFullRepositoryName(bitbucketCloudWebHook.PullRequest.ToRef.Repository),
-		Branch:           strings.TrimPrefix(bitbucketCloudWebHook.PullRequest.ToRef.ID, "refs/heads/"),
-		SourceRepository: getFullRepositoryName(bitbucketCloudWebHook.PullRequest.FromRef.Repository),
-		SourceBranch:     strings.TrimPrefix(bitbucketCloudWebHook.PullRequest.FromRef.ID, "refs/heads/"),
-		Timestamp:        eventTime.UTC().Unix(),
-		Event:            event,
+		PullRequestId:           bitbucketCloudWebHook.PullRequest.ID,
+		TargetRepositoryDetails: webhook.getRepositoryDetails(bitbucketCloudWebHook.PullRequest.ToRef.Repository),
+		Branch:                  strings.TrimPrefix(bitbucketCloudWebHook.PullRequest.ToRef.ID, "refs/heads/"),
+		SourceRepositoryDetails: webhook.getRepositoryDetails(bitbucketCloudWebHook.PullRequest.FromRef.Repository),
+		SourceBranch:            strings.TrimPrefix(bitbucketCloudWebHook.PullRequest.FromRef.ID, "refs/heads/"),
+		Timestamp:               eventTime.UTC().Unix(),
+		Event:                   event,
 	}, nil
 }
 
@@ -106,8 +114,4 @@ type bitbucketServerWebHook struct {
 	Changes     []struct {
 		RefId string `json:"refId,omitempty"`
 	} `json:"changes,omitempty"`
-}
-
-func getFullRepositoryName(repository bitbucketv1.Repository) string {
-	return strings.ToLower(repository.Project.Key) + "/" + repository.Name
 }

--- a/vcsutils/webhookparser/bitbucketserver_test.go
+++ b/vcsutils/webhookparser/bitbucketserver_test.go
@@ -40,7 +40,7 @@ func TestBitbucketServerParseIncomingPushWebhook(t *testing.T) {
 	// Check values
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, bitbucketServerPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
 }
@@ -63,7 +63,7 @@ func TestBitbucketServerParseIncomingPrCreateWebhook(t *testing.T) {
 	assert.Equal(t, bitbucketServerExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, bitbucketServerPrCreateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
@@ -89,7 +89,7 @@ func TestBitbucketServerParseIncomingPrUpdateWebhook(t *testing.T) {
 	assert.Equal(t, bitbucketServerExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, bitbucketServerPrUpdateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)

--- a/vcsutils/webhookparser/bitbucketserver_test.go
+++ b/vcsutils/webhookparser/bitbucketserver_test.go
@@ -38,7 +38,8 @@ func TestBitbucketServerParseIncomingPushWebhook(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check values
-	assert.Equal(t, "~"+expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, bitbucketServerPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
@@ -60,10 +61,12 @@ func TestBitbucketServerParseIncomingPrCreateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, bitbucketServerExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, "~"+expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, bitbucketServerPrCreateExpectedTime, actual.Timestamp)
-	assert.Equal(t, "~"+expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrCreated, actual.Event)
 }
@@ -84,10 +87,12 @@ func TestBitbucketServerParseIncomingPrUpdateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, bitbucketServerExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, "~"+expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, bitbucketServerPrUpdateExpectedTime, actual.Timestamp)
-	assert.Equal(t, "~"+expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrEdited, actual.Event)
 }

--- a/vcsutils/webhookparser/common_test.go
+++ b/vcsutils/webhookparser/common_test.go
@@ -3,7 +3,8 @@ package webhookparser
 import "os"
 
 const (
-	expectedRepoName     = "yahavi/hello-world"
+	expectedOwner        = "yahavi"
+	expectedRepoName     = "hello-world"
 	expectedBranch       = "main"
 	expectedSourceBranch = "dev"
 )

--- a/vcsutils/webhookparser/github.go
+++ b/vcsutils/webhookparser/github.go
@@ -52,9 +52,9 @@ func (webhook *GitHubWebhook) parsePushEvent(event *github.PushEvent) *WebhookIn
 			Name:  *event.GetRepo().Name,
 			Owner: *event.GetRepo().Owner.Login,
 		},
-		Branch:    strings.TrimPrefix(event.GetRef(), "refs/heads/"),
-		Timestamp: event.GetHeadCommit().GetTimestamp().UTC().Unix(),
-		Event:     vcsutils.Push,
+		TargetBranch: strings.TrimPrefix(event.GetRef(), "refs/heads/"),
+		Timestamp:    event.GetHeadCommit().GetTimestamp().UTC().Unix(),
+		Event:        vcsutils.Push,
 	}
 }
 
@@ -74,7 +74,7 @@ func (webhook *GitHubWebhook) parsePrEvents(event *github.PullRequestEvent) *Web
 			Name:  *event.GetPullRequest().GetBase().GetRepo().Name,
 			Owner: *event.GetPullRequest().GetBase().GetRepo().Owner.Login,
 		},
-		Branch: event.GetPullRequest().GetBase().GetRef(),
+		TargetBranch: event.GetPullRequest().GetBase().GetRef(),
 		SourceRepositoryDetails: WebHookInfoRepoDetails{
 			Name:  *event.GetPullRequest().GetHead().GetRepo().Name,
 			Owner: *event.GetPullRequest().GetHead().GetRepo().Owner.Login,

--- a/vcsutils/webhookparser/github.go
+++ b/vcsutils/webhookparser/github.go
@@ -48,10 +48,13 @@ func (webhook *GitHubWebhook) parseIncomingWebhook(payload []byte) (*WebhookInfo
 
 func (webhook *GitHubWebhook) parsePushEvent(event *github.PushEvent) *WebhookInfo {
 	return &WebhookInfo{
-		Repository: event.GetRepo().GetFullName(),
-		Branch:     strings.TrimPrefix(event.GetRef(), "refs/heads/"),
-		Timestamp:  event.GetHeadCommit().GetTimestamp().UTC().Unix(),
-		Event:      vcsutils.Push,
+		TargetRepositoryDetails: WebHookInfoRepoDetails{
+			Name:  *event.GetRepo().Name,
+			Owner: *event.GetRepo().Owner.Login,
+		},
+		Branch:    strings.TrimPrefix(event.GetRef(), "refs/heads/"),
+		Timestamp: event.GetHeadCommit().GetTimestamp().UTC().Unix(),
+		Event:     vcsutils.Push,
 	}
 }
 
@@ -66,12 +69,18 @@ func (webhook *GitHubWebhook) parsePrEvents(event *github.PullRequestEvent) *Web
 		return nil
 	}
 	return &WebhookInfo{
-		PullRequestId:    event.GetPullRequest().GetNumber(),
-		Repository:       event.GetPullRequest().GetBase().GetRepo().GetFullName(),
-		Branch:           event.GetPullRequest().GetBase().GetRef(),
-		SourceRepository: event.GetPullRequest().GetHead().GetRepo().GetFullName(),
-		SourceBranch:     event.GetPullRequest().GetHead().GetRef(),
-		Timestamp:        event.GetPullRequest().GetUpdatedAt().UTC().Unix(),
-		Event:            webhookEvent,
+		PullRequestId: event.GetPullRequest().GetNumber(),
+		TargetRepositoryDetails: WebHookInfoRepoDetails{
+			Name:  *event.GetPullRequest().GetBase().GetRepo().Name,
+			Owner: *event.GetPullRequest().GetBase().GetRepo().Owner.Login,
+		},
+		Branch: event.GetPullRequest().GetBase().GetRef(),
+		SourceRepositoryDetails: WebHookInfoRepoDetails{
+			Name:  *event.GetPullRequest().GetHead().GetRepo().Name,
+			Owner: *event.GetPullRequest().GetHead().GetRepo().Owner.Login,
+		},
+		SourceBranch: event.GetPullRequest().GetHead().GetRef(),
+		Timestamp:    event.GetPullRequest().GetUpdatedAt().UTC().Unix(),
+		Event:        webhookEvent,
 	}
 }

--- a/vcsutils/webhookparser/github_test.go
+++ b/vcsutils/webhookparser/github_test.go
@@ -43,7 +43,8 @@ func TestGitHubParseIncomingPushWebhook(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check values
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, githubPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
@@ -66,10 +67,12 @@ func TestGitHubParseIncomingPrCreateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, gitHubExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, githubPrCreateExpectedTime, actual.Timestamp)
-	assert.Equal(t, expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrCreated, actual.Event)
 }
@@ -91,10 +94,12 @@ func TestGitHubParseIncomingPrUpdateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, gitHubExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, githubPrUpdateExpectedTime, actual.Timestamp)
-	assert.Equal(t, expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrEdited, actual.Event)
 }

--- a/vcsutils/webhookparser/github_test.go
+++ b/vcsutils/webhookparser/github_test.go
@@ -45,7 +45,7 @@ func TestGitHubParseIncomingPushWebhook(t *testing.T) {
 	// Check values
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, githubPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
 }
@@ -69,7 +69,7 @@ func TestGitHubParseIncomingPrCreateWebhook(t *testing.T) {
 	assert.Equal(t, gitHubExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, githubPrCreateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
@@ -96,7 +96,7 @@ func TestGitHubParseIncomingPrUpdateWebhook(t *testing.T) {
 	assert.Equal(t, gitHubExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, githubPrUpdateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)

--- a/vcsutils/webhookparser/gitlab.go
+++ b/vcsutils/webhookparser/gitlab.go
@@ -54,7 +54,7 @@ func (webhook *GitLabWebhook) parseIncomingWebhook(payload []byte) (*WebhookInfo
 func (webhook *GitLabWebhook) parsePushEvent(event *gitlab.PushEvent) *WebhookInfo {
 	return &WebhookInfo{
 		TargetRepositoryDetails: webhook.parseRepoDetails(event.Project.PathWithNamespace),
-		Branch:                  strings.TrimPrefix(event.Ref, "refs/heads/"),
+		TargetBranch:            strings.TrimPrefix(event.Ref, "refs/heads/"),
 		Timestamp:               event.Commits[0].Timestamp.Local().Unix(),
 		Event:                   vcsutils.Push,
 	}
@@ -84,7 +84,7 @@ func (webhook *GitLabWebhook) parsePrEvents(event *gitlab.MergeEvent) (*WebhookI
 		SourceRepositoryDetails: webhook.parseRepoDetails(event.ObjectAttributes.Source.PathWithNamespace),
 		SourceBranch:            event.ObjectAttributes.SourceBranch,
 		TargetRepositoryDetails: webhook.parseRepoDetails(event.ObjectAttributes.Target.PathWithNamespace),
-		Branch:                  event.ObjectAttributes.TargetBranch,
+		TargetBranch:            event.ObjectAttributes.TargetBranch,
 		Timestamp:               eventTime.UTC().Unix(),
 		Event:                   webhookEvent,
 	}, nil

--- a/vcsutils/webhookparser/gitlab_test.go
+++ b/vcsutils/webhookparser/gitlab_test.go
@@ -33,7 +33,8 @@ func TestGitLabParseIncomingPushWebhook(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check values
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, gitlabPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
@@ -55,10 +56,12 @@ func TestGitLabParseIncomingPrCreateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, gitlabExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, gitlabPrCreateExpectedTime, actual.Timestamp)
-	assert.Equal(t, expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrCreated, actual.Event)
 }
@@ -79,10 +82,12 @@ func TestGitLabParseIncomingPrUpdateWebhook(t *testing.T) {
 
 	// Check values
 	assert.Equal(t, gitlabExpectedPrId, actual.PullRequestId)
-	assert.Equal(t, expectedRepoName, actual.Repository)
+	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
 	assert.Equal(t, expectedBranch, actual.Branch)
 	assert.Equal(t, gitlabPrUpdateExpectedTime, actual.Timestamp)
-	assert.Equal(t, expectedRepoName, actual.SourceRepository)
+	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
+	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 	assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 	assert.Equal(t, vcsutils.PrEdited, actual.Event)
 }

--- a/vcsutils/webhookparser/gitlab_test.go
+++ b/vcsutils/webhookparser/gitlab_test.go
@@ -35,7 +35,7 @@ func TestGitLabParseIncomingPushWebhook(t *testing.T) {
 	// Check values
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, gitlabPushExpectedTime, actual.Timestamp)
 	assert.Equal(t, vcsutils.Push, actual.Event)
 }
@@ -58,7 +58,7 @@ func TestGitLabParseIncomingPrCreateWebhook(t *testing.T) {
 	assert.Equal(t, gitlabExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, gitlabPrCreateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
@@ -84,7 +84,7 @@ func TestGitLabParseIncomingPrUpdateWebhook(t *testing.T) {
 	assert.Equal(t, gitlabExpectedPrId, actual.PullRequestId)
 	assert.Equal(t, expectedRepoName, actual.TargetRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.TargetRepositoryDetails.Owner)
-	assert.Equal(t, expectedBranch, actual.Branch)
+	assert.Equal(t, expectedBranch, actual.TargetBranch)
 	assert.Equal(t, gitlabPrUpdateExpectedTime, actual.Timestamp)
 	assert.Equal(t, expectedRepoName, actual.SourceRepositoryDetails.Name)
 	assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)

--- a/vcsutils/webhookparser/webhookparser.go
+++ b/vcsutils/webhookparser/webhookparser.go
@@ -13,7 +13,7 @@ type WebhookInfo struct {
 	// The target repository for pull requests and push
 	TargetRepositoryDetails WebHookInfoRepoDetails `json:"target_repository_details,omitempty"`
 	// The target branch for pull requests and push
-	Branch string `json:"branch,omitempty"`
+	TargetBranch string `json:"branch,omitempty"`
 	// Pull request id
 	PullRequestId int `json:"pull_request_id,omitempty"`
 	// The source repository for pull requests

--- a/vcsutils/webhookparser/webhookparser.go
+++ b/vcsutils/webhookparser/webhookparser.go
@@ -11,19 +11,24 @@ const EventHeaderKey = "X-Event-Key"
 // This struct is used for parsing an incoming webhook request from the VCS provider.
 type WebhookInfo struct {
 	// The target repository for pull requests and push
-	Repository string `json:"repository,omitempty"`
+	TargetRepositoryDetails WebHookInfoRepoDetails `json:"target_repository_details,omitempty"`
 	// The target branch for pull requests and push
 	Branch string `json:"branch,omitempty"`
 	// Pull request id
 	PullRequestId int `json:"pull_request_id,omitempty"`
 	// The source repository for pull requests
-	SourceRepository string `json:"source_repository,omitempty"`
+	SourceRepositoryDetails WebHookInfoRepoDetails `json:"source_repository_details,omitempty"`
 	// The source branch for pull requests
 	SourceBranch string `json:"source_branch,omitempty"`
 	// Seconds from epoch
 	Timestamp int64 `json:"timestamp,omitempty"`
 	// The event type
 	Event vcsutils.WebhookEvent `json:"event,omitempty"`
+}
+
+type WebHookInfoRepoDetails struct {
+	Name  string `json:"name,omitempty"`
+	Owner string `json:"owner,omitempty"`
 }
 
 type WebhookParser interface {


### PR DESCRIPTION
This returns the repo owner and name as distinct field, and also fixes some inconsistencies with GetRepositories where we would return the slug and the webhook would return the name