### PR TITLE
Fix get latest commit for gitlab returns empty

### DIFF
--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -198,6 +198,35 @@ func TestBitbucketCloud_GetLatestCommitNotFound(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestBitbucketCloud_GetLatestCommitUnknownBranch(t *testing.T) {
+	ctx := context.Background()
+	response := []byte(`{
+		"data": {
+			"shas": [
+				"unknown"
+			]
+		},
+		"error": {
+			"data": {
+				"shas": [
+					"unknown"
+				]
+			},
+			"message": "Commit not found"
+		},
+		"type": "error"
+	}`)
+
+	client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.BitbucketCloud, true, response,
+		fmt.Sprintf("/repositories/%s/%s/commits/%s?pagelen=1", owner, repo1, "unknown"), http.StatusNotFound,
+		createBitbucketCloudHandler)
+	defer cleanUp()
+
+	result, err := client.GetLatestCommit(ctx, owner, repo1, "unknown")
+	require.EqualError(t, err, "404 Not Found")
+	assert.Empty(t, result)
+}
+
 func TestBitbucketCloud_AddSshKeyToRepository(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud", "add_ssh_key_response.json"))

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -3,6 +3,7 @@ package vcsclient
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -222,7 +223,7 @@ func (client *GitLabClient) GetLatestCommit(ctx context.Context, owner, reposito
 		latestCommit := commits[0]
 		return mapGitLabCommitToCommitInfo(latestCommit), nil
 	}
-	return CommitInfo{}, nil
+	return CommitInfo{}, errors.New(`{"message":"404 Not Found"}`)
 }
 
 // GetRepositoryInfo on GitLab

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -195,6 +195,21 @@ func TestGitLabClient_GetLatestCommitNotFound(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestGitLabClient_GetLatestCommitUnknownBranch(t *testing.T) {
+	ctx := context.Background()
+
+	client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitLab, false, []byte("[]"),
+		fmt.Sprintf("/api/v4/projects/%s/repository/commits?page=1&per_page=1&ref_name=unknown",
+			url.PathEscape(owner+"/"+repo1)), http.StatusOK, createGitLabHandler)
+	defer cleanUp()
+
+	result, err := client.GetLatestCommit(ctx, owner, repo1, "unknown")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404 Not Found")
+	assert.Empty(t, result)
+}
+
 func TestGitLabClient_AddSshKeyToRepository(t *testing.T) {
 	ctx := context.Background()
 	response := []byte(`{


### PR DESCRIPTION
fixes #9

- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
