### PR TITLE
30 - panic if push has no commits

### DIFF
--- a/vcsutils/webhookparser/gitlab.go
+++ b/vcsutils/webhookparser/gitlab.go
@@ -54,10 +54,14 @@ func (webhook *GitLabWebhook) parseIncomingWebhook(payload []byte) (*WebhookInfo
 }
 
 func (webhook *GitLabWebhook) parsePushEvent(event *gitlab.PushEvent) *WebhookInfo {
+	var localTimestamp int64
+	if len(event.Commits) > 0 {
+		localTimestamp = event.Commits[0].Timestamp.Local().Unix()
+	}
 	return &WebhookInfo{
 		TargetRepositoryDetails: webhook.parseRepoDetails(event.Project.PathWithNamespace),
 		TargetBranch:            strings.TrimPrefix(event.Ref, "refs/heads/"),
-		Timestamp:               event.Commits[0].Timestamp.Local().Unix(),
+		Timestamp:               localTimestamp,
 		Event:                   vcsutils.Push,
 	}
 }


### PR DESCRIPTION
GitLab provider panics if push event has no Commits
provided. Fix it by checking presents of at least one
commit object before getting a timestamp.

- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [-] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---

Closes: https://github.com/jfrog/froggit-go/issues/30