### PR TITLE
Support labels API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
   - [Delete Webhook](#delete-webhook)
   - [Set Commit Status](#set-commit-status)
   - [Create Pull Request](#create-pull-request)
-  - [Unlabel Pull Request](#unlabel-pull-request)
   - [Get Latest Commit](#get-latest-commit)
   - [Get Commit By SHA](#get-commit-by-sha)
   - [Add Public SSH Key](#add-public-ssh-key)
   - [Get Repository Info](#get-repository-info)
   - [Create a Label](#create-a-label)
   - [Get a Label](#get-a-label)
+  - [Unlabel Pull Request](#unlabel-pull-request)
 - [Webhook Parser](#webhook-parser)
 
 ### VCS Clients
@@ -259,26 +259,6 @@ description := "Pull request description"
 err := client.CreatePullRequest(ctx, owner, repository, sourceBranch, targetBranch, title, description)
 ```
 
-##### Unlabel Pull Request
-
-Notice - Labels are not supported in Bitbucket
-
-```go
-// Go context
-ctx := context.Background()
-// Organization or username
-owner := "jfrog"
-// VCS repository
-repository := "jfrog-cli"
-// Label name
-name := "label-name"
-// Pull Request ID
-pullRequestID := 5
-
-// Remove label "label-name" from pull request 5
-err := client.UnlabelPullRequest(ctx, owner, repository, name, pullRequestID)
-```
-
 #### Get Latest Commit
 
 ```go
@@ -382,6 +362,26 @@ labelName := "label-name"
 
 // Get a label named "label-name"
 labelInfo, err := client.GetLabel(ctx, owner, repository, labelName)
+```
+
+#### Unlabel Pull Request
+
+Notice - Labels are not supported in Bitbucket
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// Label name
+name := "label-name"
+// Pull Request ID
+pullRequestID := 5
+
+// Remove label "label-name" from pull request 5
+err := client.UnlabelPullRequest(ctx, owner, repository, name, pullRequestID)
 ```
 
 ### Webhook Parser

--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
   - [Delete Webhook](#delete-webhook)
   - [Set Commit Status](#set-commit-status)
   - [Create Pull Request](#create-pull-request)
+  - [Unlabel Pull Request](#unlabel-pull-request)
   - [Get Latest Commit](#get-latest-commit)
   - [Get Commit By SHA](#get-commit-by-sha)
   - [Add Public SSH Key](#add-public-ssh-key)
   - [Get Repository Info](#get-repository-info)
+  - [Create a Label](#create-a-label)
+  - [Get a Label](#get-a-label)
 - [Webhook Parser](#webhook-parser)
 
 ### VCS Clients
@@ -253,7 +256,27 @@ title := "Pull request title"
 // Pull request description
 description := "Pull request description"
 
-err := client.CreatePullRequest(ctx, owner, repository, sourceBranch, targetBranch, title, description string)
+err := client.CreatePullRequest(ctx, owner, repository, sourceBranch, targetBranch, title, description)
+```
+
+##### Unlabel Pull Request
+
+Notice - Labels are not supported in Bitbucket
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// Label name
+name := "label-name"
+// Pull Request ID
+pullRequestID := 5
+
+// Remove label "label-name" from pull request 5
+err := client.UnlabelPullRequest(ctx, owner, repository, name, pullRequestID)
 ```
 
 #### Get Latest Commit
@@ -320,6 +343,45 @@ repository := "jfrog-cli"
 
 // Get information about repository
 repoInfo, err := client.GetRepositoryInfo(ctx, owner, repository)
+```
+
+#### Create a label
+
+Notice - Labels are not supported in Bitbucket
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// Label info
+labelInfo := LabelInfo{
+  Name:        "label-name",
+  Description: "label description",
+  Color:       "4AB548",
+}
+// Create a label
+err := client.CreateLabel(ctx, owner, repository, labelInfo)
+```
+
+#### Get a label
+
+Notice - Labels are not supported in Bitbucket
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// Label name
+labelName := "label-name"
+
+// Get a label named "label-name"
+labelInfo, err := client.GetLabel(ctx, owner, repository, labelName)
 ```
 
 ### Webhook Parser

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -259,11 +259,6 @@ func (client *BitbucketCloudClient) CreatePullRequest(ctx context.Context, owner
 	return err
 }
 
-// UnlabelPullRequest on Bitbucket cloud
-func (client *BitbucketCloudClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
-	return errLabelsNotSupported
-}
-
 // GetLatestCommit on Bitbucket cloud
 func (client *BitbucketCloudClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{
@@ -369,6 +364,11 @@ func (client *BitbucketCloudClient) CreateLabel(ctx context.Context, owner, repo
 // GetLabel on Bitbucket cloud
 func (client *BitbucketCloudClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
 	return nil, errLabelsNotSupported
+}
+
+// UnlabelPullRequest on Bitbucket cloud
+func (client *BitbucketCloudClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	return errLabelsNotSupported
 }
 
 func extractCommitFromResponse(commits interface{}) (*commitResponse, error) {

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -259,6 +259,11 @@ func (client *BitbucketCloudClient) CreatePullRequest(ctx context.Context, owner
 	return err
 }
 
+// UnlabelPullRequest on Bitbucket cloud
+func (client *BitbucketCloudClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	return getLabelsUnsupportedError()
+}
+
 // GetLatestCommit on Bitbucket cloud
 func (client *BitbucketCloudClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{
@@ -354,6 +359,16 @@ func (client *BitbucketCloudClient) GetCommitBySha(ctx context.Context, owner, r
 		return CommitInfo{}, err
 	}
 	return mapBitbucketCloudCommitToCommitInfo(parsedCommit), nil
+}
+
+// CreateLabel on Bitbucket cloud
+func (client *BitbucketCloudClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
+	return getLabelsUnsupportedError()
+}
+
+// GetLabel on Bitbucket cloud
+func (client *BitbucketCloudClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
+	return nil, getLabelsUnsupportedError()
 }
 
 func extractCommitFromResponse(commits interface{}) (*commitResponse, error) {

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -261,7 +261,7 @@ func (client *BitbucketCloudClient) CreatePullRequest(ctx context.Context, owner
 
 // UnlabelPullRequest on Bitbucket cloud
 func (client *BitbucketCloudClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
-	return getLabelsUnsupportedError()
+	return errLabelsNotSupported
 }
 
 // GetLatestCommit on Bitbucket cloud
@@ -363,12 +363,12 @@ func (client *BitbucketCloudClient) GetCommitBySha(ctx context.Context, owner, r
 
 // CreateLabel on Bitbucket cloud
 func (client *BitbucketCloudClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
-	return getLabelsUnsupportedError()
+	return errLabelsNotSupported
 }
 
 // GetLabel on Bitbucket cloud
 func (client *BitbucketCloudClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
-	return nil, getLabelsUnsupportedError()
+	return nil, errLabelsNotSupported
 }
 
 func extractCommitFromResponse(commits interface{}) (*commitResponse, error) {

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -12,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/google/uuid"
 	"github.com/jfrog/froggit-go/vcsutils"
@@ -159,6 +160,15 @@ func TestBitbucketCloud_CreatePullRequest(t *testing.T) {
 
 	err := client.CreatePullRequest(ctx, owner, repo1, branch1, branch2, "PR title", "PR body")
 	assert.NoError(t, err)
+}
+
+func TestBitbucketCloud_UnlabelPullRequest(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
+	assert.NoError(t, err)
+
+	err = client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 
 func TestBitbucketCloud_GetLatestCommit(t *testing.T) {
@@ -340,6 +350,24 @@ func TestBitbucketCloud_GetRepositoryInfo(t *testing.T) {
 		},
 		res,
 	)
+}
+
+func TestBitbucketCloud_CreateLabel(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
+	assert.NoError(t, err)
+
+	err = client.CreateLabel(ctx, owner, repo1, LabelInfo{})
+	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
+func TestBitbucketCloud_GetLabel(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
+	assert.NoError(t, err)
+
+	_, err = client.GetLabel(ctx, owner, repo1, labelName)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 
 func createBitbucketCloudHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -162,15 +162,6 @@ func TestBitbucketCloud_CreatePullRequest(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestBitbucketCloud_UnlabelPullRequest(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
-	assert.NoError(t, err)
-
-	err = client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
-	assert.ErrorIs(t, err, errLabelsNotSupported)
-}
-
 func TestBitbucketCloud_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud", "commit_list_response.json"))
@@ -367,6 +358,15 @@ func TestBitbucketCloud_GetLabel(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = client.GetLabel(ctx, owner, repo1, labelName)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
+func TestBitbucketCloud_UnlabelPullRequest(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
+	assert.NoError(t, err)
+
+	err = client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
 	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -1,6 +1,10 @@
 package vcsclient
 
-import "fmt"
+import (
+	"errors"
+)
+
+var errLabelsNotSupported = errors.New("labels are not supported on Bitbucket")
 
 func getBitbucketCommitState(commitState CommitStatus) string {
 	switch commitState {
@@ -12,8 +16,4 @@ func getBitbucketCommitState(commitState CommitStatus) string {
 		return "INPROGRESS"
 	}
 	return ""
-}
-
-func getLabelsUnsupportedError() error {
-	return fmt.Errorf("labels are not supported on Bitbucket")
 }

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -1,5 +1,7 @@
 package vcsclient
 
+import "fmt"
+
 func getBitbucketCommitState(commitState CommitStatus) string {
 	switch commitState {
 	case Pass:
@@ -10,4 +12,8 @@ func getBitbucketCommitState(commitState CommitStatus) string {
 		return "INPROGRESS"
 	}
 	return ""
+}
+
+func getLabelsUnsupportedError() error {
+	return fmt.Errorf("labels are not supported on Bitbucket")
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -289,7 +289,7 @@ func (client *BitbucketServerClient) CreatePullRequest(ctx context.Context, owne
 
 // UnlabelPullRequest on Bitbucket server
 func (client *BitbucketServerClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
-	return getLabelsUnsupportedError()
+	return errLabelsNotSupported
 }
 
 type projectsResponse struct {
@@ -405,12 +405,12 @@ func (client BitbucketServerClient) GetCommitBySha(ctx context.Context, owner, r
 
 // CreateLabel on Bitbucket server
 func (client BitbucketServerClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
-	return getLabelsUnsupportedError()
+	return errLabelsNotSupported
 }
 
 // GetLabel on Bitbucket server
 func (client *BitbucketServerClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
-	return nil, getLabelsUnsupportedError()
+	return nil, errLabelsNotSupported
 }
 
 // Get all projects for which the authenticated user has the PROJECT_VIEW permission

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -287,11 +287,6 @@ func (client *BitbucketServerClient) CreatePullRequest(ctx context.Context, owne
 	return err
 }
 
-// UnlabelPullRequest on Bitbucket server
-func (client *BitbucketServerClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
-	return errLabelsNotSupported
-}
-
 type projectsResponse struct {
 	Values []struct {
 		Key string `json:"key,omitempty"`
@@ -411,6 +406,11 @@ func (client BitbucketServerClient) CreateLabel(ctx context.Context, owner, repo
 // GetLabel on Bitbucket server
 func (client *BitbucketServerClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
 	return nil, errLabelsNotSupported
+}
+
+// UnlabelPullRequest on Bitbucket server
+func (client *BitbucketServerClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	return errLabelsNotSupported
 }
 
 // Get all projects for which the authenticated user has the PROJECT_VIEW permission

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -287,6 +287,11 @@ func (client *BitbucketServerClient) CreatePullRequest(ctx context.Context, owne
 	return err
 }
 
+// UnlabelPullRequest on Bitbucket server
+func (client *BitbucketServerClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	return getLabelsUnsupportedError()
+}
+
 type projectsResponse struct {
 	Values []struct {
 		Key string `json:"key,omitempty"`
@@ -396,6 +401,16 @@ func (client BitbucketServerClient) GetCommitBySha(ctx context.Context, owner, r
 		return CommitInfo{}, err
 	}
 	return client.mapBitbucketServerCommitToCommitInfo(commit, owner, repository), nil
+}
+
+// CreateLabel on Bitbucket server
+func (client BitbucketServerClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
+	return getLabelsUnsupportedError()
+}
+
+// GetLabel on Bitbucket server
+func (client *BitbucketServerClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
+	return nil, getLabelsUnsupportedError()
 }
 
 // Get all projects for which the authenticated user has the PROJECT_VIEW permission

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -185,15 +185,6 @@ func TestBitbucketServer_CreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestBitbucketServer_UnlabelPullRequest(t *testing.T) {
-	ctx := context.Background()
-	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()
-	assert.NoError(t, err)
-
-	err = client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
-	assert.ErrorIs(t, err, errLabelsNotSupported)
-}
-
 func TestBitbucketServer_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver", "commit_list_response.json"))
@@ -385,6 +376,15 @@ func TestBitbucketServer_GetLabel(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = client.GetLabel(ctx, owner, repo1, labelName)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
+func TestBitbucketServer_UnlabelPullRequest(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()
+	assert.NoError(t, err)
+
+	err = client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
 	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -185,6 +185,15 @@ func TestBitbucketServer_CreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBitbucketServer_UnlabelPullRequest(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()
+	assert.NoError(t, err)
+
+	err = client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
 func TestBitbucketServer_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver", "commit_list_response.json"))
@@ -359,6 +368,24 @@ func TestBitbucketServer_GetRepositoryInfo(t *testing.T) {
 
 	_, err = createBadBitbucketServerClient(t).GetRepositoryInfo(ctx, owner, repo1)
 	assert.Error(t, err)
+}
+
+func TestBitbucketServer_CreateLabel(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()
+	assert.NoError(t, err)
+
+	err = client.CreateLabel(ctx, owner, repo1, LabelInfo{})
+	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
+func TestBitbucketServer_GetLabel(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()
+	assert.NoError(t, err)
+
+	_, err = client.GetLabel(ctx, owner, repo1, labelName)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 
 func TestBitbucketServer_GetCommitBySha(t *testing.T) {

--- a/vcsclient/common_test.go
+++ b/vcsclient/common_test.go
@@ -18,11 +18,12 @@ const (
 )
 
 var (
-	repo1    = "repo-1"
-	repo2    = "repo-2"
-	username = "frogger"
-	branch1  = "branch-1"
-	branch2  = "branch-2"
+	repo1     = "repo-1"
+	repo2     = "repo-2"
+	username  = "frogger"
+	branch1   = "branch-1"
+	branch2   = "branch-2"
+	labelName = "🚀 label-name"
 )
 
 type createHandlerFunc func(t *testing.T, expectedUri string, response []byte, expectedStatusCode int) http.HandlerFunc

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -225,6 +225,17 @@ func (client *GitHubClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
+// UnlabelPullRequest on GitHub
+func (client *GitHubClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	ghClient, err := client.buildGithubClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = ghClient.Issues.RemoveLabelForIssue(ctx, owner, repository, pullRequestID, name)
+	return err
+}
+
 // GetLatestCommit on GitHub
 func (client *GitHubClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{
@@ -299,6 +310,54 @@ func (client *GitHubClient) GetCommitBySha(ctx context.Context, owner, repositor
 	}
 
 	return mapGitHubCommitToCommitInfo(commit), nil
+}
+
+// CreateLabel on GitHub
+func (client *GitHubClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "LabelInfo.name": labelInfo.Name})
+	if err != nil {
+		return err
+	}
+
+	ghClient, err := client.buildGithubClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, _, err = ghClient.Issues.CreateLabel(ctx, owner, repository, &github.Label{
+		Name:        &labelInfo.Name,
+		Description: &labelInfo.Description,
+		Color:       &labelInfo.Color,
+	})
+
+	return err
+}
+
+// GetLabel on GitHub
+func (client *GitHubClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "name": name})
+	if err != nil {
+		return nil, err
+	}
+
+	ghClient, err := client.buildGithubClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	label, response, err := ghClient.Issues.GetLabel(ctx, owner, repository, name)
+	if err != nil {
+		if response.Response.StatusCode == http.StatusNotFound {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	return &LabelInfo{
+		Name:        *label.Name,
+		Description: *label.Description,
+		Color:       *label.Color,
+	}, err
 }
 
 func createGitHubHook(token, payloadURL string, webhookEvents ...vcsutils.WebhookEvent) *github.Hook {

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -225,17 +225,6 @@ func (client *GitHubClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
-// UnlabelPullRequest on GitHub
-func (client *GitHubClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
-	ghClient, err := client.buildGithubClient(ctx)
-	if err != nil {
-		return err
-	}
-
-	_, err = ghClient.Issues.RemoveLabelForIssue(ctx, owner, repository, pullRequestID, name)
-	return err
-}
-
 // GetLatestCommit on GitHub
 func (client *GitHubClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{
@@ -358,6 +347,17 @@ func (client *GitHubClient) GetLabel(ctx context.Context, owner, repository, nam
 		Description: *label.Description,
 		Color:       *label.Color,
 	}, err
+}
+
+// UnlabelPullRequest on GitHub
+func (client *GitHubClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	ghClient, err := client.buildGithubClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = ghClient.Issues.RemoveLabelForIssue(ctx, owner, repository, pullRequestID, name)
+	return err
 }
 
 func createGitHubHook(token, payloadURL string, webhookEvents ...vcsutils.WebhookEvent) *github.Hook {

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -185,18 +185,6 @@ func TestGitHubClient_CreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestGitHubClient_UnlabelPullRequest(t *testing.T) {
-	ctx := context.Background()
-	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.PullRequest{}, fmt.Sprintf("/repos/jfrog/repo-1/issues/1/labels/%s", url.PathEscape(labelName)), createGitHubHandler)
-	defer cleanUp()
-
-	err := client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
-	assert.NoError(t, err)
-
-	err = createBadGitHubClient(t).UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
-	assert.Error(t, err)
-}
-
 func TestGitHubClient_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "github", "commit_list_response.json"))
@@ -424,6 +412,18 @@ func TestGitGubClient_GetLabelNotExisted(t *testing.T) {
 	actualLabel, err := client.GetLabel(ctx, owner, repo1, "not-existed")
 	assert.NoError(t, err)
 	assert.Nil(t, actualLabel)
+}
+
+func TestGitHubClient_UnlabelPullRequest(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.PullRequest{}, fmt.Sprintf("/repos/jfrog/repo-1/issues/1/labels/%s", url.PathEscape(labelName)), createGitHubHandler)
+	defer cleanUp()
+
+	err := client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
+	assert.NoError(t, err)
+
+	err = createBadGitHubClient(t).UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
+	assert.Error(t, err)
 }
 
 func createBadGitHubClient(t *testing.T) VcsClient {

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/xanzy/go-gitlab"
@@ -196,6 +197,14 @@ func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
+// UnlabelPullRequest on GitLab
+func (client *GitLabClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	_, _, err := client.glClient.MergeRequests.UpdateMergeRequest(getProjectID(owner, repository), pullRequestID, &gitlab.UpdateMergeRequestOptions{
+		RemoveLabels: gitlab.Labels{name},
+	}, gitlab.WithContext(ctx))
+	return err
+}
+
 // GetLatestCommit on GitLab
 func (client *GitLabClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{
@@ -257,6 +266,46 @@ func (client *GitLabClient) GetCommitBySha(ctx context.Context, owner, repositor
 		return CommitInfo{}, err
 	}
 	return mapGitLabCommitToCommitInfo(commit), nil
+}
+
+// CreateLabel on GitLab
+func (client *GitLabClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "LabelInfo.name": labelInfo.Name})
+	if err != nil {
+		return err
+	}
+
+	_, _, err = client.glClient.Labels.CreateLabel(getProjectID(owner, repository), &gitlab.CreateLabelOptions{
+		Name:        &labelInfo.Name,
+		Description: &labelInfo.Description,
+		Color:       &labelInfo.Color,
+	}, gitlab.WithContext(ctx))
+
+	return err
+}
+
+func (client *GitLabClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "name": name})
+	if err != nil {
+		return nil, err
+	}
+
+	labels, _, err := client.glClient.Labels.ListLabels(getProjectID(owner, repository), &gitlab.ListLabelsOptions{}, gitlab.WithContext(ctx))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, label := range labels {
+		if label.Name == name {
+			return &LabelInfo{
+				Name:        label.Name,
+				Description: label.Description,
+				Color:       strings.TrimPrefix(label.Color, "#"),
+			}, err
+		}
+	}
+
+	return nil, nil
 }
 
 func getProjectID(owner, project string) string {

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -197,14 +197,6 @@ func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
-// UnlabelPullRequest on GitLab
-func (client *GitLabClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
-	_, _, err := client.glClient.MergeRequests.UpdateMergeRequest(getProjectID(owner, repository), pullRequestID, &gitlab.UpdateMergeRequestOptions{
-		RemoveLabels: gitlab.Labels{name},
-	}, gitlab.WithContext(ctx))
-	return err
-}
-
 // GetLatestCommit on GitLab
 func (client *GitLabClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{
@@ -284,6 +276,7 @@ func (client *GitLabClient) CreateLabel(ctx context.Context, owner, repository s
 	return err
 }
 
+// GetLabel on GitLub
 func (client *GitLabClient) GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error) {
 	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "name": name})
 	if err != nil {
@@ -306,6 +299,14 @@ func (client *GitLabClient) GetLabel(ctx context.Context, owner, repository, nam
 	}
 
 	return nil, nil
+}
+
+// UnlabelPullRequest on GitLab
+func (client *GitLabClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
+	_, _, err := client.glClient.MergeRequests.UpdateMergeRequest(getProjectID(owner, repository), pullRequestID, &gitlab.UpdateMergeRequestOptions{
+		RemoveLabels: gitlab.Labels{name},
+	}, gitlab.WithContext(ctx))
+	return err
 }
 
 func getProjectID(owner, project string) string {

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -359,6 +359,16 @@ func TestGitlabClient_GetLabel(t *testing.T) {
 	assert.Nil(t, labelInfo)
 }
 
+func TestGitlabClient_UnlabelPullRequest(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, nil,
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests/1", url.PathEscape(owner+"/"+repo1)), createGitLabHandler)
+	defer cleanUp()
+
+	err := client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
+	assert.NoError(t, err)
+}
+
 func createGitLabHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.RequestURI == "/api/v4/" {

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -103,13 +103,6 @@ type VcsClient interface {
 	// description  - Pull request description
 	CreatePullRequest(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) error
 
-	// UnlabelPullRequest remove a label from a pull request
-	// owner         - User or organization
-	// repository    - VCS repository name
-	// name          - Label name
-	// pullRequestID - Pull request ID
-	UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error
-
 	// GetLatestCommit Get the most recent commit of a branch
 	// owner      - User or organization
 	// repository - VCS repository name
@@ -146,6 +139,13 @@ type VcsClient interface {
 	// repository - VCS repository name
 	// name       - Label name
 	GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error)
+
+	// UnlabelPullRequest remove a label from a pull request
+	// owner         - User or organization
+	// repository    - VCS repository name
+	// name          - Label name
+	// pullRequestID - Pull request ID
+	UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error
 }
 
 // CommitInfo contains the details of a commit

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -3,8 +3,9 @@ package vcsclient
 import (
 	"context"
 	"fmt"
-	"github.com/jfrog/froggit-go/vcsutils"
 	"strings"
+
+	"github.com/jfrog/froggit-go/vcsutils"
 )
 
 // CommitStatus the status of the commit in the VCS
@@ -102,30 +103,49 @@ type VcsClient interface {
 	// description  - Pull request description
 	CreatePullRequest(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) error
 
+	// UnlabelPullRequest remove a label from a pull request
+	// owner         - User or organization
+	// repository    - VCS repository name
+	// name          - Label name
+	// pullRequestID - Pull request ID
+	UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error
+
 	// GetLatestCommit Get the most recent commit of a branch
-	// owner        - User or organization
-	// repository   - VCS repository name
-	// branch       - The name of the branch
+	// owner      - User or organization
+	// repository - VCS repository name
+	// branch     - The name of the branch
 	GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error)
 
 	// AddSshKeyToRepository Add a public ssh key to a repository
-	// owner        - User or organization
-	// repository   - VCS repository name
-	// keyName      - Name of the key
-	// publicKey    - SSH public key
-	// permission   - Access permission of the key: read or readWrite
+	// owner      - User or organization
+	// repository - VCS repository name
+	// keyName    - Name of the key
+	// publicKey  - SSH public key
+	// permission - Access permission of the key: read or readWrite
 	AddSshKeyToRepository(ctx context.Context, owner, repository, keyName, publicKey string, permission Permission) error
 
 	// GetRepositoryInfo Returns information about repository.
-	// owner        - User or organization
-	// repository   - VCS repository name
+	// owner      - User or organization
+	// repository - VCS repository name
 	GetRepositoryInfo(ctx context.Context, owner, repository string) (RepositoryInfo, error)
 
 	// GetCommitBySha Get the commit by its SHA
-	// owner        - User or organization
-	// repository   - VCS repository name
-	// sha          - The commit hash
+	// owner      - User or organization
+	// repository - VCS repository name
+	// sha        - The commit hash
 	GetCommitBySha(ctx context.Context, owner, repository, sha string) (CommitInfo, error)
+
+	// CreateLabel create a label in repository
+	// owner      - User or organization
+	// repository - VCS repository name
+	// labelInfo  - The label info
+	CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error
+
+	// GetLabel get a label related to a repository. Returns (nil, nil) if label doesn't exist.
+	// owner      - User or organization
+	// repository - VCS repository name
+	// name       - Label name
+	GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error)
 }
 
 // CommitInfo contains the details of a commit
@@ -157,6 +177,14 @@ type CloneInfo struct {
 	HTTP string
 	// SSH is a URL string to clone repository using SSH protocol.
 	SSH string
+}
+
+// LabelInfo contains a label information
+type LabelInfo struct {
+	Name        string
+	Description string
+	// Label color is a hexadecimal color code, for example: 4AB548
+	Color string
 }
 
 func validateParametersNotBlank(paramNameValueMap map[string]string) error {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [ ] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
Add labels APIs for GitHub and GitLab.
Currently, labels in Bitbucket are not supported: https://jira.atlassian.com/browse/BSERV-10715