### PR TITLE
Add list pull request labels API

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
   - [Get Repository Info](#get-repository-info)
   - [Create a Label](#create-a-label)
   - [Get a Label](#get-a-label)
+  - [List Pull Request Labels](#list-pull-request-labels)
   - [Unlabel Pull Request](#unlabel-pull-request)
 - [Webhook Parser](#webhook-parser)
 
@@ -362,6 +363,24 @@ labelName := "label-name"
 
 // Get a label named "label-name"
 labelInfo, err := client.GetLabel(ctx, owner, repository, labelName)
+```
+
+#### List Pull Request Labels
+
+Notice - Labels are not supported in Bitbucket
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// Pull Request ID
+pullRequestID := 5
+
+// List all labels assigned to pull request 5
+err := client.ListPullRequestLabels(ctx, owner, repository, pullRequestID)
 ```
 
 #### Unlabel Pull Request

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -366,6 +366,11 @@ func (client *BitbucketCloudClient) GetLabel(ctx context.Context, owner, reposit
 	return nil, errLabelsNotSupported
 }
 
+// ListPullRequestLabels on Bitbucket cloud
+func (client *BitbucketCloudClient) ListPullRequestLabels(ctx context.Context, owner, repository string, pullRequestID int) ([]string, error) {
+	return nil, errLabelsNotSupported
+}
+
 // UnlabelPullRequest on Bitbucket cloud
 func (client *BitbucketCloudClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
 	return errLabelsNotSupported

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -361,6 +361,15 @@ func TestBitbucketCloud_GetLabel(t *testing.T) {
 	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 
+func TestBitbucketCloud_ListPullRequestLabels(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
+	assert.NoError(t, err)
+
+	_, err = client.ListPullRequestLabels(ctx, owner, repo1, 1)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
 func TestBitbucketCloud_UnlabelPullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -408,6 +408,11 @@ func (client *BitbucketServerClient) GetLabel(ctx context.Context, owner, reposi
 	return nil, errLabelsNotSupported
 }
 
+// ListPullRequestLabels on Bitbucket server
+func (client *BitbucketServerClient) ListPullRequestLabels(ctx context.Context, owner, repository string, pullRequestID int) ([]string, error) {
+	return nil, errLabelsNotSupported
+}
+
 // UnlabelPullRequest on Bitbucket server
 func (client *BitbucketServerClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
 	return errLabelsNotSupported

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -379,6 +379,15 @@ func TestBitbucketServer_GetLabel(t *testing.T) {
 	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 
+func TestBitbucketServer_ListPullRequestLabels(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()
+	assert.NoError(t, err)
+
+	_, err = client.ListPullRequestLabels(ctx, owner, repo1, 1)
+	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
 func TestBitbucketServer_UnlabelPullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()

--- a/vcsclient/common_test.go
+++ b/vcsclient/common_test.go
@@ -103,3 +103,9 @@ func getAllProviders() []vcsutils.VcsProvider {
 		vcsutils.GitHub, vcsutils.GitLab, vcsutils.BitbucketServer, vcsutils.BitbucketCloud,
 	}
 }
+
+func getNonBitbucketProviders() []vcsutils.VcsProvider {
+	return []vcsutils.VcsProvider{
+		vcsutils.GitHub, vcsutils.GitLab,
+	}
+}

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -414,9 +414,23 @@ func TestGitGubClient_GetLabelNotExisted(t *testing.T) {
 	assert.Nil(t, actualLabel)
 }
 
+func TestGitHubClient_ListPullRequestLabels(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, []*github.Label{{Name: &labelName}}, "/repos/jfrog/repo-1/issues/1/labels", createGitHubHandler)
+	defer cleanUp()
+
+	labels, err := client.ListPullRequestLabels(ctx, owner, repo1, 1)
+	assert.NoError(t, err)
+	assert.Len(t, labels, 1)
+	assert.Equal(t, labelName, labels[0])
+
+	_, err = createBadGitHubClient(t).ListPullRequestLabels(ctx, owner, repo1, 1)
+	assert.Error(t, err)
+}
+
 func TestGitHubClient_UnlabelPullRequest(t *testing.T) {
 	ctx := context.Background()
-	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.PullRequest{}, fmt.Sprintf("/repos/jfrog/repo-1/issues/1/labels/%s", url.PathEscape(labelName)), createGitHubHandler)
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, &github.PullRequest{}, fmt.Sprintf("/repos/jfrog/repo-1/issues/1/labels/%s", url.PathEscape(labelName)), createGitHubHandler)
 	defer cleanUp()
 
 	err := client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -301,9 +301,28 @@ func (client *GitLabClient) GetLabel(ctx context.Context, owner, repository, nam
 	return nil, nil
 }
 
+// ListPullRequestLabels on GitLab
+func (client *GitLabClient) ListPullRequestLabels(ctx context.Context, owner, repository string, pullRequestID int) ([]string, error) {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository})
+	if err != nil {
+		return []string{}, err
+	}
+	mergeRequest, _, err := client.glClient.MergeRequests.GetMergeRequest(getProjectID(owner, repository), pullRequestID,
+		&gitlab.GetMergeRequestsOptions{}, gitlab.WithContext(ctx))
+	if err != nil {
+		return []string{}, err
+	}
+
+	return mergeRequest.Labels, nil
+}
+
 // UnlabelPullRequest on GitLab
 func (client *GitLabClient) UnlabelPullRequest(ctx context.Context, owner, repository, name string, pullRequestID int) error {
-	_, _, err := client.glClient.MergeRequests.UpdateMergeRequest(getProjectID(owner, repository), pullRequestID, &gitlab.UpdateMergeRequestOptions{
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository})
+	if err != nil {
+		return err
+	}
+	_, _, err = client.glClient.MergeRequests.UpdateMergeRequest(getProjectID(owner, repository), pullRequestID, &gitlab.UpdateMergeRequestOptions{
 		RemoveLabels: gitlab.Labels{name},
 	}, gitlab.WithContext(ctx))
 	return err

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -359,6 +359,18 @@ func TestGitlabClient_GetLabel(t *testing.T) {
 	assert.Nil(t, labelInfo)
 }
 
+func TestGitlabClient_ListPullRequestLabels(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, &gitlab.MergeRequest{Labels: gitlab.Labels{labelName}},
+		fmt.Sprintf("/api/v4/projects/%s/merge_requests/1", url.PathEscape(owner+"/"+repo1)), createGitLabHandler)
+	defer cleanUp()
+
+	labels, err := client.ListPullRequestLabels(ctx, owner, repo1, 1)
+	assert.NoError(t, err)
+	assert.Len(t, labels, 1)
+	assert.Equal(t, labelName, labels[0])
+}
+
 func TestGitlabClient_UnlabelPullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, nil,

--- a/vcsclient/validate_required_params_test.go
+++ b/vcsclient/validate_required_params_test.go
@@ -2,149 +2,61 @@ package vcsclient
 
 import (
 	"context"
+	"fmt"
+	"testing"
+
+	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRequiredParams_AddSshKeyInvalidPayload(t *testing.T) {
 	tests := []struct {
-		name       string
-		owner      string
-		repo       string
-		keyName    string
-		publicKey  string
-		assertFunc func(*testing.T, error)
+		name          string
+		owner         string
+		repo          string
+		keyName       string
+		publicKey     string
+		missingParams []string
 	}{
-		{
-			name:      "all empty",
-			owner:     "",
-			repo:      "",
-			keyName:   "",
-			publicKey: "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.Error(t, err)
-				message := err.Error()
-				assert.Contains(t, message, "required parameter 'owner' is missing")
-				assert.Contains(t, message, "required parameter 'repository' is missing")
-				assert.Contains(t, message, "required parameter 'key name' is missing")
-				assert.Contains(t, message, "required parameter 'public key' is missing")
-			},
-		},
-		{
-			name:      "empty owner",
-			owner:     "",
-			repo:      "repo",
-			keyName:   "my key",
-			publicKey: "ssh-rsa AAAA..",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'owner' is missing")
-			},
-		},
-		{
-			name:      "empty repo",
-			owner:     "owner",
-			repo:      "",
-			keyName:   "my key",
-			publicKey: "ssh-rsa AAAA..",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'repository' is missing")
-			},
-		},
-		{
-			name:      "empty keyName",
-			owner:     "owner",
-			repo:      "repo",
-			keyName:   "",
-			publicKey: "ssh-rsa AAAA..",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'key name' is missing")
-			},
-		},
-		{
-			name:      "empty publicKey",
-			owner:     "owner",
-			repo:      "repo",
-			keyName:   "my key",
-			publicKey: "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'public key' is missing")
-			},
-		},
+		{name: "all empty", missingParams: []string{"owner", "repository", "key name", "public key"}},
+		{name: "empty owner", repo: "repo", keyName: "my key", publicKey: "ssh-rsa AAAA..", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", keyName: "my key", publicKey: "ssh-rsa AAAA..", missingParams: []string{"repository"}},
+		{name: "empty keyName", owner: "owner", repo: "repo", publicKey: "ssh-rsa AAAA..", missingParams: []string{"key name"}},
+		{name: "empty publicKey", owner: "owner", repo: "repo", keyName: "my key", missingParams: []string{"public key"}},
 	}
 
 	for _, p := range getAllProviders() {
 		for _, tt := range tests {
 			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
-				ctx := context.Background()
-				client, err := NewClientBuilder(p).Build()
-				require.NoError(t, err)
-				err = client.AddSshKeyToRepository(ctx, tt.owner, tt.repo, tt.keyName, tt.publicKey, Read)
-				tt.assertFunc(t, err)
+				ctx, client := createClientAndContext(t, p)
+				err := client.AddSshKeyToRepository(ctx, tt.owner, tt.repo, tt.keyName, tt.publicKey, Read)
+				assertMissingParam(t, err, tt.missingParams...)
 			})
 		}
 	}
 }
 
-func TestRequiredParams__GetLatestCommitInvalidPayload(t *testing.T) {
+func TestRequiredParams_GetLatestCommitInvalidPayload(t *testing.T) {
 	tests := []struct {
-		name       string
-		owner      string
-		repo       string
-		branch     string
-		assertFunc func(*testing.T, error)
+		name          string
+		owner         string
+		repo          string
+		branch        string
+		missingParams []string
 	}{
-		{
-			name:   "all empty",
-			owner:  "",
-			repo:   "",
-			branch: "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.Error(t, err)
-				message := err.Error()
-				assert.Contains(t, message, "required parameter 'owner' is missing")
-				assert.Contains(t, message, "required parameter 'repository' is missing")
-				assert.Contains(t, message, "required parameter 'branch' is missing")
-			},
-		},
-		{
-			name:   "empty owner",
-			owner:  "",
-			repo:   "repo",
-			branch: "branch",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'owner' is missing")
-			},
-		},
-		{
-			name:   "empty repo",
-			owner:  "owner",
-			repo:   "",
-			branch: "branch",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'repository' is missing")
-			},
-		},
-		{
-			name:   "empty branch",
-			owner:  "owner",
-			repo:   "repo",
-			branch: "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'branch' is missing")
-			},
-		},
+		{name: "all empty", missingParams: []string{"owner", "repository", "branch"}},
+		{name: "empty owner", repo: "repo", branch: "branch", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", branch: "branch", missingParams: []string{"repository"}},
+		{name: "empty branch", owner: "owner", repo: "repo", missingParams: []string{"branch"}},
 	}
 
 	for _, p := range getAllProviders() {
 		for _, tt := range tests {
 			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
-				ctx := context.Background()
-				client, err := NewClientBuilder(p).Build()
-				require.NoError(t, err)
-
+				ctx, client := createClientAndContext(t, p)
 				result, err := client.GetLatestCommit(ctx, tt.owner, tt.repo, tt.branch)
-				tt.assertFunc(t, err)
+				assertMissingParam(t, err, tt.missingParams...)
 				assert.Empty(t, result)
 			})
 		}
@@ -153,116 +65,164 @@ func TestRequiredParams__GetLatestCommitInvalidPayload(t *testing.T) {
 
 func TestRequiredParams_GetRepositoryInfoInvalidPayload(t *testing.T) {
 	tests := []struct {
-		name       string
-		owner      string
-		repo       string
-		assertFunc func(*testing.T, error)
+		name          string
+		owner         string
+		repo          string
+		missingParams []string
 	}{
-		{
-			name:  "all empty",
-			owner: "",
-			repo:  "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.Error(t, err)
-				message := err.Error()
-				assert.Contains(t, message, "required parameter 'owner' is missing")
-				assert.Contains(t, message, "required parameter 'repository' is missing")
-			},
-		},
-		{
-			name:  "empty owner",
-			owner: "",
-			repo:  "repo",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'owner' is missing")
-			},
-		},
-		{
-			name:  "empty repo",
-			owner: "owner",
-			repo:  "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'repository' is missing")
-			},
-		},
+		{name: "all empty", missingParams: []string{"owner", "repository"}},
+		{name: "empty owner", repo: "repo", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", missingParams: []string{"repository"}},
 	}
 
 	for _, p := range getAllProviders() {
 		for _, tt := range tests {
 			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
-				ctx := context.Background()
-				client, err := NewClientBuilder(p).Build()
-				require.NoError(t, err)
-
+				ctx, client := createClientAndContext(t, p)
 				result, err := client.GetRepositoryInfo(ctx, tt.owner, tt.repo)
-				tt.assertFunc(t, err)
+				assertMissingParam(t, err, tt.missingParams...)
 				assert.Empty(t, result)
 			})
 		}
 	}
 }
 
-func TestRequiredParams__GetCommitByShaInvalidPayload(t *testing.T) {
+func TestRequiredParams_GetCommitByShaInvalidPayload(t *testing.T) {
 	tests := []struct {
-		name       string
-		owner      string
-		repo       string
-		sha        string
-		assertFunc func(*testing.T, error)
+		name          string
+		owner         string
+		repo          string
+		sha           string
+		missingParams []string
 	}{
-		{
-			name:  "all empty",
-			owner: "",
-			repo:  "",
-			sha:   "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.Error(t, err)
-				message := err.Error()
-				assert.Contains(t, message, "required parameter 'owner' is missing")
-				assert.Contains(t, message, "required parameter 'repository' is missing")
-				assert.Contains(t, message, "required parameter 'sha' is missing")
-			},
-		},
-		{
-			name:  "empty owner",
-			owner: "",
-			repo:  "repo",
-			sha:   "sha",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'owner' is missing")
-			},
-		},
-		{
-			name:  "empty repo",
-			owner: "owner",
-			repo:  "",
-			sha:   "sha",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'repository' is missing")
-			},
-		},
-		{
-			name:  "empty branch",
-			owner: "owner",
-			repo:  "repo",
-			sha:   "",
-			assertFunc: func(t *testing.T, err error) {
-				assert.EqualError(t, err, "validation failed: required parameter 'sha' is missing")
-			},
-		},
+		{name: "all empty", missingParams: []string{"owner", "repository", "sha"}},
+		{name: "empty owner", repo: "repo", sha: "sha", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", sha: "sha", missingParams: []string{"repository"}},
+		{name: "empty branch", owner: "owner", repo: "repo", missingParams: []string{"sha"}},
 	}
 
 	for _, p := range getAllProviders() {
 		for _, tt := range tests {
 			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
-				ctx := context.Background()
-				client, err := NewClientBuilder(p).Build()
-				require.NoError(t, err)
-
+				ctx, client := createClientAndContext(t, p)
 				result, err := client.GetCommitBySha(ctx, tt.owner, tt.repo, tt.sha)
-				tt.assertFunc(t, err)
+				assertMissingParam(t, err, tt.missingParams...)
 				assert.Empty(t, result)
 			})
 		}
+	}
+}
+
+func TestRequiredParams_CreateLabel(t *testing.T) {
+	tests := []struct {
+		name          string
+		owner         string
+		repo          string
+		labelInfo     LabelInfo
+		missingParams []string
+	}{
+		{name: "all empty", labelInfo: LabelInfo{}, missingParams: []string{"owner", "repository", "LabelInfo.name"}},
+		{name: "empty owner", repo: "repo", labelInfo: LabelInfo{Name: "name"}, missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", labelInfo: LabelInfo{Name: "name"}, missingParams: []string{"repository"}},
+		{name: "empty LabelInfo.name", owner: "owner", repo: "repo", labelInfo: LabelInfo{}, missingParams: []string{"LabelInfo.name"}},
+	}
+
+	for _, p := range getNonBitbucketProviders() {
+		for _, tt := range tests {
+			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
+				ctx, client := createClientAndContext(t, p)
+				err := client.CreateLabel(ctx, tt.owner, tt.repo, tt.labelInfo)
+				assertMissingParam(t, err, tt.missingParams...)
+			})
+		}
+	}
+}
+
+func TestRequiredParams_GetLabel(t *testing.T) {
+	tests := []struct {
+		name          string
+		owner         string
+		repo          string
+		labelName     string
+		missingParams []string
+	}{
+		{name: "all empty", missingParams: []string{"owner", "repository", "name"}},
+		{name: "empty owner", repo: "repo", labelName: "name", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", labelName: "name", missingParams: []string{"repository"}},
+		{name: "empty name", owner: "owner", repo: "repo", missingParams: []string{"name"}},
+	}
+
+	for _, p := range getNonBitbucketProviders() {
+		for _, tt := range tests {
+			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
+				ctx, client := createClientAndContext(t, p)
+				result, err := client.GetLabel(ctx, tt.owner, tt.repo, tt.labelName)
+				assertMissingParam(t, err, tt.missingParams...)
+				assert.Empty(t, result)
+			})
+		}
+	}
+}
+
+func TestRequiredParams_ListPullRequestLabels(t *testing.T) {
+	tests := []struct {
+		name          string
+		owner         string
+		repo          string
+		missingParams []string
+	}{
+		{name: "all empty", missingParams: []string{"owner", "repository"}},
+		{name: "empty owner", repo: "repo", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", missingParams: []string{"repository"}},
+	}
+
+	for _, p := range getNonBitbucketProviders() {
+		for _, tt := range tests {
+			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
+				ctx, client := createClientAndContext(t, p)
+				result, err := client.ListPullRequestLabels(ctx, tt.owner, tt.repo, 0)
+				assertMissingParam(t, err, tt.missingParams...)
+				assert.Empty(t, result)
+			})
+		}
+	}
+}
+
+func TestRequiredParams_UnlabelPullRequest(t *testing.T) {
+	tests := []struct {
+		name          string
+		owner         string
+		repo          string
+		labelName     string
+		missingParams []string
+	}{
+		{name: "all empty", missingParams: []string{"owner", "repository"}},
+		{name: "empty owner", repo: "repo", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", missingParams: []string{"repository"}},
+	}
+
+	for _, p := range getNonBitbucketProviders() {
+		for _, tt := range tests {
+			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
+				ctx, client := createClientAndContext(t, p)
+				err := client.UnlabelPullRequest(ctx, tt.owner, tt.repo, tt.labelName, 0)
+				assertMissingParam(t, err, tt.missingParams...)
+			})
+		}
+	}
+}
+
+func createClientAndContext(t *testing.T, provider vcsutils.VcsProvider) (context.Context, VcsClient) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(provider).Build()
+	require.NoError(t, err)
+	return ctx, client
+}
+
+func assertMissingParam(t *testing.T, err error, missingParam ...string) {
+	assert.Error(t, err)
+	message := err.Error()
+	for _, param := range missingParam {
+		assert.Contains(t, message, fmt.Sprintf("required parameter '%s' is missing", param))
 	}
 }

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -140,6 +140,12 @@ type VcsClient interface {
 	// name       - Label name
 	GetLabel(ctx context.Context, owner, repository, name string) (*LabelInfo, error)
 
+	// ListPullRequestLabels get all labels assigned to a pull request.
+	// owner         - User or organization
+	// repository    - VCS repository name
+	// pullRequestID - Pull request ID
+	ListPullRequestLabels(ctx context.Context, owner, repository string, pullRequestID int) ([]string, error)
+
 	// UnlabelPullRequest remove a label from a pull request
 	// owner         - User or organization
 	// repository    - VCS repository name


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---

* Add ListPullRequestLabels on the VscClient.
* Add missing validateParametersNotBlank on UnlabelPullRequest in GitHub.
* Refactor validate_required_params_test