### PR TITLE
Support add comment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
   - [Delete Webhook](#delete-webhook)
   - [Set Commit Status](#set-commit-status)
   - [Create Pull Request](#create-pull-request)
+  - [Add Pull Request Comment](#add-pull-request-comment)
   - [Get Latest Commit](#get-latest-commit)
   - [Get Commit By SHA](#get-commit-by-sha)
   - [Add Public SSH Key](#add-public-ssh-key)
@@ -258,6 +259,23 @@ title := "Pull request title"
 description := "Pull request description"
 
 err := client.CreatePullRequest(ctx, owner, repository, sourceBranch, targetBranch, title, description)
+```
+
+##### Add Pull Request Comment
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// Comment content
+content := "Comment content"
+// Pull Request ID
+pullRequestID := 5
+
+err := client.AddPullRequestComment(ctx, owner, repository, content, pullRequestID)
 ```
 
 #### Get Latest Commit

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -5,11 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/mitchellh/mapstructure"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/mitchellh/mapstructure"
 
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/ktrysmt/go-bitbucket"
@@ -256,6 +257,23 @@ func (client *BitbucketCloudClient) CreatePullRequest(ctx context.Context, owner
 		Description:       description,
 	}
 	_, err := bitbucketClient.Repositories.PullRequests.Create(options)
+	return err
+}
+
+// AddPullRequestComment on Bitbucket cloud
+func (client *BitbucketCloudClient) AddPullRequestComment(ctx context.Context, owner, repository, content string, pullRequestID int) error {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "content": content})
+	if err != nil {
+		return err
+	}
+	bitbucketClient := client.buildBitbucketCloudClient(ctx)
+	options := &bitbucket.PullRequestCommentOptions{
+		Owner:         owner,
+		RepoSlug:      repository,
+		PullRequestID: fmt.Sprint(pullRequestID),
+		Content:       content,
+	}
+	_, err = bitbucketClient.Repositories.PullRequests.AddComment(options)
 	return err
 }
 

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -162,6 +162,15 @@ func TestBitbucketCloud_CreatePullRequest(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestBitbucketCloud_AddPullRequestComment(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketCloud, true, nil, "/repositories/jfrog/repo-1/pullrequests/1/comments", createBitbucketCloudHandler)
+	defer cleanUp()
+
+	err := client.AddPullRequestComment(ctx, owner, repo1, "Comment content", 1)
+	assert.NoError(t, err)
+}
+
 func TestBitbucketCloud_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud", "commit_list_response.json"))

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -6,14 +6,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
-	"github.com/jfrog/froggit-go/vcsutils"
-	"github.com/mitchellh/mapstructure"
-	"golang.org/x/oauth2"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
+
+	bitbucketv1 "github.com/gfleury/go-bitbucket-v1"
+	"github.com/jfrog/froggit-go/vcsutils"
+	"github.com/mitchellh/mapstructure"
+	"golang.org/x/oauth2"
 )
 
 // BitbucketServerClient API version 1.0
@@ -284,6 +285,23 @@ func (client *BitbucketServerClient) CreatePullRequest(ctx context.Context, owne
 		},
 	}
 	_, err = bitbucketClient.CreatePullRequest(owner, repository, options)
+	return err
+}
+
+// AddPullRequestComment on Bitbucket server
+func (client *BitbucketServerClient) AddPullRequestComment(ctx context.Context, owner, repository, content string, pullRequestID int) error {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "content": content})
+	if err != nil {
+		return err
+	}
+	bitbucketClient, err := client.buildBitbucketClient(ctx)
+	if err != nil {
+		return err
+	}
+	_, err = bitbucketClient.CreatePullRequestComment(owner, repository, pullRequestID, bitbucketv1.Comment{
+		Text: content,
+	}, []string{"application/json"})
+
 	return err
 }
 

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -185,6 +185,18 @@ func TestBitbucketServer_CreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBitbucketServer_AddPullRequestComment(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, nil, "/api/1.0/projects/jfrog/repos/repo-1/pull-requests/1/comments", createBitbucketServerHandler)
+	defer cleanUp()
+
+	err := client.AddPullRequestComment(ctx, owner, repo1, "Comment content", 1)
+	assert.NoError(t, err)
+
+	err = createBadBitbucketServerClient(t).AddPullRequestComment(ctx, owner, repo1, "Comment content", 1)
+	assert.Error(t, err)
+}
+
 func TestBitbucketServer_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver", "commit_list_response.json"))

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -225,6 +225,23 @@ func (client *GitHubClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
+// AddPullRequestComment on GitHub
+func (client *GitHubClient) AddPullRequestComment(ctx context.Context, owner, repository, content string, pullRequestID int) error {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "content": content})
+	if err != nil {
+		return err
+	}
+	ghClient, err := client.buildGithubClient(ctx)
+	if err != nil {
+		return err
+	}
+	// We use the Issues API to add a regular comment. The PullRequests API adds a code review comment.
+	_, _, err = ghClient.Issues.CreateComment(ctx, owner, repository, pullRequestID, &github.IssueComment{
+		Body: &content,
+	})
+	return err
+}
+
 // GetLatestCommit on GitHub
 func (client *GitHubClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -185,6 +185,18 @@ func TestGitHubClient_CreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGitHubClient_AddPullRequestComment(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.IssueComment{}, "/repos/jfrog/repo-1/issues/1/comments", createGitHubHandler)
+	defer cleanUp()
+
+	err := client.AddPullRequestComment(ctx, owner, repo1, "Comment content", 1)
+	assert.NoError(t, err)
+
+	err = createBadGitHubClient(t).AddPullRequestComment(ctx, owner, repo1, "Comment content", 1)
+	assert.Error(t, err)
+}
+
 func TestGitHubClient_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "github", "commit_list_response.json"))

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -197,6 +197,21 @@ func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
+// AddPullRequestComment on GitLab
+func (client *GitLabClient) AddPullRequestComment(ctx context.Context, owner, repository, content string, pullRequestID int) error {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repository": repository, "content": content})
+	if err != nil {
+		return err
+	}
+	options := &gitlab.CreateMergeRequestNoteOptions{
+		Body: &content,
+	}
+	_, _, err = client.glClient.Notes.CreateMergeRequestNote(getProjectID(owner, repository), pullRequestID, options,
+		gitlab.WithContext(ctx))
+
+	return err
+}
+
 // GetLatestCommit on GitLab
 func (client *GitLabClient) GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -154,6 +154,15 @@ func TestGitLabClient_CreatePullRequest(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGitLabClient_AddPullRequestComment(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, &gitlab.MergeRequest{}, fmt.Sprintf("/api/v4/projects/%s/merge_requests/1/notes", url.PathEscape(owner+"/"+repo1)), createGitLabHandler)
+	defer cleanUp()
+
+	err := client.AddPullRequestComment(ctx, owner, repo1, "Comment content", 1)
+	assert.NoError(t, err)
+}
+
 func TestGitLabClient_GetLatestCommit(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "gitlab", "commit_list_response.json"))

--- a/vcsclient/validate_required_params_test.go
+++ b/vcsclient/validate_required_params_test.go
@@ -113,6 +113,31 @@ func TestRequiredParams_GetCommitByShaInvalidPayload(t *testing.T) {
 	}
 }
 
+func TestRequiredParams_AddPullRequestComment(t *testing.T) {
+	tests := []struct {
+		name          string
+		owner         string
+		repo          string
+		content       string
+		missingParams []string
+	}{
+		{name: "all empty", missingParams: []string{"owner", "repository", "content"}},
+		{name: "empty owner", repo: "repo", content: "content", missingParams: []string{"owner"}},
+		{name: "empty repo", owner: "owner", content: "content", missingParams: []string{"repository"}},
+		{name: "empty content", owner: "owner", missingParams: []string{"content"}},
+	}
+
+	for _, p := range getAllProviders() {
+		for _, tt := range tests {
+			t.Run(p.String()+" "+tt.name, func(t *testing.T) {
+				ctx, client := createClientAndContext(t, p)
+				err := client.AddPullRequestComment(ctx, tt.owner, tt.repo, tt.content, 0)
+				assertMissingParam(t, err, tt.missingParams...)
+			})
+		}
+	}
+}
+
 func TestRequiredParams_CreateLabel(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -103,6 +103,13 @@ type VcsClient interface {
 	// description  - Pull request description
 	CreatePullRequest(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) error
 
+	// AddPullRequestComment Add a new comment on the requested pull request
+	// owner          - User or organization
+	// repository     - VCS repository name
+	// content        - The new comment content
+	// pullRequestID  - Pull request ID
+	AddPullRequestComment(ctx context.Context, owner, repository, content string, pullRequestID int) error
+
 	// GetLatestCommit Get the most recent commit of a branch
 	// owner      - User or organization
 	// repository - VCS repository name


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---

Supersede https://github.com/jfrog/froggit-go/pull/34