### PR TITLE
Bug fix: download repository branch from bitbucket server

### DIFF
--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -253,7 +253,12 @@ func (client *BitbucketServerClient) DownloadRepository(ctx context.Context, own
 	if err != nil {
 		return err
 	}
-	response, err := bitbucketClient.GetArchive(owner, repository, map[string]interface{}{"format": "tgz", "at": branch})
+	params := map[string]interface{}{"format": "tgz"}
+	branch = strings.TrimSpace(branch)
+	if branch != "" {
+		params["at"] = branch
+	}
+	response, err := bitbucketClient.GetArchive(owner, repository, params)
 	if err != nil {
 		return err
 	}

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -248,12 +248,12 @@ func (client *BitbucketServerClient) SetCommitStatus(ctx context.Context, commit
 }
 
 // DownloadRepository on Bitbucket server
-func (client *BitbucketServerClient) DownloadRepository(ctx context.Context, owner, repository, _, localPath string) error {
+func (client *BitbucketServerClient) DownloadRepository(ctx context.Context, owner, repository, branch, localPath string) error {
 	bitbucketClient, err := client.buildBitbucketClient(ctx)
 	if err != nil {
 		return err
 	}
-	response, err := bitbucketClient.GetArchive(owner, repository, map[string]interface{}{"format": "tgz"})
+	response, err := bitbucketClient.GetArchive(owner, repository, map[string]interface{}{"format": "tgz", "at": branch})
 	if err != nil {
 		return err
 	}

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -164,7 +164,7 @@ func TestBitbucketServer_DownloadRepository(t *testing.T) {
 		fmt.Sprintf("/api/1.0/projects/%s/repos/%s/archive?format=tgz", owner, repo1), createBitbucketServerHandler)
 	defer cleanUp()
 
-	err = client.DownloadRepository(ctx, owner, repo1, "irrelevant", dir)
+	err = client.DownloadRepository(ctx, owner, repo1, "", dir)
 	require.NoError(t, err)
 
 	_, err = os.OpenFile(filepath.Join(dir, "README.md"), os.O_RDONLY, 0644)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
