### PR TITLE
Fix Github ListOpenPullRequests

### DIFF
--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -556,14 +556,14 @@ func mapGitHubCommentToCommentInfoList(commentsList []*github.IssueComment) (res
 func mapGitHubPullRequestToPullRequestInfoList(pullRequestList []*github.PullRequest) (res []PullRequestInfo, err error) {
 	for _, pullRequest := range pullRequestList {
 		res = append(res, PullRequestInfo{
-			ID: *pullRequest.ID,
+			ID: int64(*pullRequest.Number),
 			Source: BranchInfo{
 				Name:       *pullRequest.Head.Ref,
-				Repository: *pullRequest.Head.Repo.FullName,
+				Repository: *pullRequest.Head.Repo.Name,
 			},
 			Target: BranchInfo{
 				Name:       *pullRequest.Base.Ref,
-				Repository: *pullRequest.Base.Repo.FullName,
+				Repository: *pullRequest.Base.Repo.Name,
 			},
 		})
 	}

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -490,8 +490,8 @@ func TestGitHubClient_ListOpenPullRequests(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     1,
-		Source: BranchInfo{Name: "new-topic", Repository: "octocat/Hello-World"},
-		Target: BranchInfo{Name: "master", Repository: "octocat/Hello-World"},
+		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World"},
+		Target: BranchInfo{Name: "master", Repository: "Hello-World"},
 	}, result[0]))
 
 	_, err = createBadGitHubClient(t).ListPullRequestComments(ctx, owner, repo1, 1)

--- a/vcsclient/testdata/github/pull_requests_list_response.json
+++ b/vcsclient/testdata/github/pull_requests_list_response.json
@@ -1,7 +1,7 @@
 [
   {
     "url": "https://api.github.com/repos/octocat/Hello-World/pulls/1347",
-    "id": 1,
+    "id": 1347,
     "node_id": "MDExOlB1bGxSZXF1ZXN0MQ==",
     "html_url": "https://github.com/octocat/Hello-World/pull/1347",
     "diff_url": "https://github.com/octocat/Hello-World/pull/1347.diff",
@@ -12,7 +12,7 @@
     "review_comment_url": "https://api.github.com/repos/octocat/Hello-World/pulls/comments{/number}",
     "comments_url": "https://api.github.com/repos/octocat/Hello-World/issues/1347/comments",
     "statuses_url": "https://api.github.com/repos/octocat/Hello-World/statuses/6dcb09b5b57875f334f61aebed695e2e4193db5e",
-    "number": 1347,
+    "number": 1,
     "state": "open",
     "locked": true,
     "title": "Amazing new feature",


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
- Used in Frogbot's scan-pull-requests when using GitHub with Jenkins.