### PR TITLE
Check HTTP response status code in DownloadRepository

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -131,7 +131,7 @@ func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, rep
 		return
 	}
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		err = fmt.Errorf("bad HTTP status: %d", res.StatusCode)
+		err = fmt.Errorf(vcsutils.ErrStatusCode, res.StatusCode, http.StatusOK)
 	}
 	return
 }

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -130,8 +130,8 @@ func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, rep
 	if res, err = httpClient.Do(req); err != nil {
 		return
 	}
-	if res.StatusCode < 200 || res.StatusCode >= 300 {
-		err = fmt.Errorf(vcsutils.ErrStatusCode, res.StatusCode, http.StatusOK)
+	if err = vcsutils.CheckResponseStatusWithBody(res, http.StatusOK); err != nil {
+		return nil, err
 	}
 	return
 }

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -93,9 +93,11 @@ func (client *AzureReposClient) DownloadRepository(ctx context.Context, _, repos
 	}()
 	res, err := client.sendDownloadRepoRequest(ctx, repository, branch)
 	defer func() {
-		e := res.Body.Close()
-		if err == nil {
-			err = e
+		if res.Body != nil {
+			e := res.Body.Close()
+			if err == nil {
+				err = e
+			}
 		}
 	}()
 	if err != nil {
@@ -131,7 +133,7 @@ func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, rep
 		return
 	}
 	if err = vcsutils.CheckResponseStatusWithBody(res, http.StatusOK); err != nil {
-		return nil, err
+		return &http.Response{}, err
 	}
 	return
 }

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -241,9 +241,10 @@ func (client *BitbucketCloudClient) DownloadRepository(ctx context.Context, owne
 		return err
 	}
 
-	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf(vcsutils.ErrStatusCode, response.StatusCode, http.StatusOK)
+	if err = vcsutils.CheckResponseStatusWithBody(response, http.StatusOK); err != nil {
+		return err
 	}
+
 	return vcsutils.Untar(localPath, response.Body, true)
 }
 

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -240,6 +240,10 @@ func (client *BitbucketCloudClient) DownloadRepository(ctx context.Context, owne
 	if err != nil {
 		return err
 	}
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf(vcsutils.ErrStatusCode, response.StatusCode, http.StatusOK)
+	}
 	return vcsutils.Untar(localPath, response.Body, true)
 }
 

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -3,6 +3,7 @@ package vcsclient
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"github.com/google/go-github/v45/github"
 	"github.com/grokify/mogo/encoding/base64"
 	"github.com/jfrog/froggit-go/vcsutils"
@@ -206,6 +207,9 @@ func (client *GitHubClient) DownloadRepository(ctx context.Context, owner, repos
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf(vcsutils.ErrStatusCode, resp.StatusCode, http.StatusOK)
+	}
 	return vcsutils.Untar(localPath, resp.Body, true)
 }
 

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -3,7 +3,6 @@ package vcsclient
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/google/go-github/v45/github"
 	"github.com/grokify/mogo/encoding/base64"
 	"github.com/jfrog/froggit-go/vcsutils"
@@ -207,9 +206,10 @@ func (client *GitHubClient) DownloadRepository(ctx context.Context, owner, repos
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf(vcsutils.ErrStatusCode, resp.StatusCode, http.StatusOK)
+	if err = vcsutils.CheckResponseStatusWithBody(resp, http.StatusOK); err != nil {
+		return err
 	}
+
 	return vcsutils.Untar(localPath, resp.Body, true)
 }
 

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"github.com/google/uuid"
 	"io"
@@ -13,8 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 )
-
-var ErrStatusCode = "invalid status code. received %d while %d status code is expected"
 
 // CreateToken create a random UUID
 func CreateToken() string {
@@ -225,4 +224,35 @@ func unzipFile(f *zip.File, destination string) (err error) {
 		}
 	}()
 	return safeCopy(destinationFile, zippedFile)
+}
+
+func CheckResponseStatusWithBody(resp *http.Response, expectedStatusCodes ...int) error {
+	for _, statusCode := range expectedStatusCodes {
+		if statusCode == resp.StatusCode {
+			return nil
+		}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	return GenerateResponseError(resp.Status, generateErrorString(body))
+}
+
+func GenerateResponseError(status, body string) error {
+	responseErrString := "server response: " + status
+	if body != "" {
+		responseErrString = responseErrString + "\n" + body
+	}
+	return fmt.Errorf(responseErrString)
+}
+
+func generateErrorString(bodyArray []byte) string {
+	var content bytes.Buffer
+	if err := json.Indent(&content, bodyArray, "", "  "); err != nil {
+		return string(bodyArray)
+	}
+	return content.String()
 }

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -251,8 +251,11 @@ func GenerateResponseError(status, body string) error {
 
 func generateErrorString(bodyArray []byte) string {
 	var content bytes.Buffer
-	if err := json.Indent(&content, bodyArray, "", "  "); err != nil {
-		return string(bodyArray)
+	if len(bodyArray) > 0 {
+		if err := json.Indent(&content, bodyArray, "", "  "); err != nil {
+			return string(bodyArray)
+		}
+		return content.String()
 	}
-	return content.String()
+	return ""
 }

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 )
 
+var ErrStatusCode = fmt.Sprintf("invalid status code. received %d while %d status code is expected")
+
 // CreateToken create a random UUID
 func CreateToken() string {
 	return uuid.New().String()

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-var ErrStatusCode = fmt.Sprintf("invalid status code. received %d while %d status code is expected")
+var ErrStatusCode = "invalid status code. received %d while %d status code is expected"
 
 // CreateToken create a random UUID
 func CreateToken() string {

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -150,7 +150,6 @@ func TestGetZeroValue(t *testing.T) {
 	assert.Equal(t, 0.0, GetZeroValue[float64]())
 }
 
-<<<<<<< HEAD
 func TestGenerateResponseError(t *testing.T) {
 	status := "404"
 	emptyBodyErr := GenerateResponseError(status, "")
@@ -168,7 +167,8 @@ func TestCheckResponseStatusWithBody(t *testing.T) {
 		StatusCode: 200,
 	}
 	assert.NoError(t, CheckResponseStatusWithBody(resp, expectedStatusCode))
-=======
+}
+
 func TestCreateDotGitFolderWithRemote(t *testing.T) {
 	dir1, err := os.MkdirTemp("", "tmp")
 	assert.NoError(t, err)
@@ -191,5 +191,4 @@ func TestCreateDotGitFolderWithoutRemote(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir2)
 	assert.Error(t, CreateDotGitFolderWithRemote(dir2, "", "fakeurl"))
->>>>>>> upstream/master
 }

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -148,3 +148,22 @@ func TestGetZeroValue(t *testing.T) {
 	assert.Equal(t, "", GetZeroValue[string]())
 	assert.Equal(t, 0.0, GetZeroValue[float64]())
 }
+
+func TestGenerateResponseError(t *testing.T) {
+	status := "404"
+	emptyBodyErr := GenerateResponseError(status, "")
+	assert.Error(t, emptyBodyErr)
+	assert.Equal(t, "server response: 404", emptyBodyErr.Error())
+	err := GenerateResponseError(status, "error")
+	assert.Error(t, err)
+	assert.Equal(t, "server response: 404\nerror", err.Error())
+}
+
+func TestCheckResponseStatusWithBody(t *testing.T) {
+	expectedStatusCode := 200
+	resp := &http.Response{
+		Status:     "200",
+		StatusCode: 200,
+	}
+	assert.NoError(t, CheckResponseStatusWithBody(resp, expectedStatusCode))
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
