### PR TITLE
Skip CreateDotGitFolderWithRemote if .git exists

### DIFF
--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -271,6 +271,10 @@ func generateErrorString(bodyArray []byte) string {
 // CreateDotGitFolderWithRemote creates a .git folder inside path with remote details of remoteName and remoteUrl
 func CreateDotGitFolderWithRemote(path, remoteName, remoteUrl string) error {
 	repo, err := git.PlainInit(path, false)
+	if err == git.ErrRepositoryAlreadyExists {
+		// If the .git folder already exists, we can skip this function
+		return nil
+	}
 	if err != nil {
 		return err
 	}

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -181,8 +181,8 @@ func TestCreateDotGitFolderWithRemote(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, remote)
 	assert.Contains(t, remote.Config().URLs, "fakeurl")
-	// Return error if .git already exist
-	assert.Error(t, CreateDotGitFolderWithRemote(dir1, "origin", "fakeurl"))
+	// Return no err if .git already exist
+	assert.NoError(t, CreateDotGitFolderWithRemote(dir1, "origin", "fakeurl"))
 }
 
 func TestCreateDotGitFolderWithoutRemote(t *testing.T) {


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [ ] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
