### PR TITLE
Add DownloadFileFromRepo API to GitHub and GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ branch := "my_branch"
 // A string representing the file path in the repository
 path := "path"
 
-// Uploads the scanning analysis file to the relevant git provider
+// Downloads a file from a repository
 content, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo, branch, path)
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
       - [List Pull Request Labels](#list-pull-request-labels)
       - [Unlabel Pull Request](#unlabel-pull-request)
       - [Upload Code Scanning](#upload-code-scanning)
-      - [Download File From Repository](#download-file-from-repository)
+      - [Download a File From a Repository](#download-a-file-from-a-repository)
     - [Webhook Parser](#webhook-parser)
 
 ### VCS Clients
@@ -517,7 +517,7 @@ scanResults := "results"
 sarifID, err := client.UploadCodeScanning(ctx, owner, repo, branch, scanResults)
 ```
 
-#### Download File From Repository
+#### Download a File From a Repository
 
 Notice - Currently supported on GitHub and GitLab.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
       - [List Pull Request Labels](#list-pull-request-labels)
       - [Unlabel Pull Request](#unlabel-pull-request)
       - [Upload Code Scanning](#upload-code-scanning)
+      - [Download File From Repository](#download-file-from-repository)
     - [Webhook Parser](#webhook-parser)
 
 ### VCS Clients
@@ -514,6 +515,26 @@ scanResults := "results"
 
 // Uploads the scanning analysis file to the relevant git provider
 sarifID, err := client.UploadCodeScanning(ctx, owner, repo, branch, scanResults)
+```
+
+#### Download File From Repository
+
+Notice - Currently supported on GitHub and GitLab.
+
+```go
+// Go context
+ctx := context.Background()
+// The account owner of the git repository
+owner := "user"
+// The name of the repository
+repo := "my_repo"
+// The branch name for which the code scanning is relevant
+branch := "my_branch"
+// A string representing the file path in the repository
+path := "path"
+
+// Uploads the scanning analysis file to the relevant git provider
+content, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo, branch, path)
 ```
 
 ### Webhook Parser

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -355,3 +355,7 @@ func (client *AzureReposClient) DeleteWebhook(ctx context.Context, owner, reposi
 func (client *AzureReposClient) SetCommitStatus(ctx context.Context, commitStatus CommitStatus, owner, repository, ref, title, description, detailsURL string) error {
 	return getUnsupportedInAzureError("set commit status")
 }
+
+func (client *AzureReposClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
+	return nil, 0, getUnsupportedInAzureError("download file from repo")
+}

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -356,6 +356,7 @@ func (client *AzureReposClient) SetCommitStatus(ctx context.Context, commitStatu
 	return getUnsupportedInAzureError("set commit status")
 }
 
+// DownloadFileFromRepo on Azure Repos
 func (client *AzureReposClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
 	return nil, 0, getUnsupportedInAzureError("download file from repo")
 }

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -317,6 +317,14 @@ func TestAzureReposClient_UploadCodeScanning(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestAzureReposClient_DownloadFileFromRepo(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, "", "unsupportedTest", createAzureReposHandler)
+	defer cleanUp()
+	_, _, err := client.DownloadFileFromRepo(ctx, owner, repo1, "", "")
+	assert.Error(t, err)
+}
+
 func TestAzureReposClient_CreateWebhook(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, "", "unsupportedTest", createAzureReposHandler)

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -460,6 +460,10 @@ func (client *BitbucketCloudClient) UploadCodeScanning(ctx context.Context, owne
 	return "", errBitbucketCodeScanningNotSupported
 }
 
+func (client *BitbucketCloudClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
+	return nil, 0, errBitbucketDownloadFileFromRepoNotSupported
+}
+
 func extractCommitFromResponse(commits interface{}) (*commitResponse, error) {
 	var res commitResponse
 	err := extractStructFromResponse(commits, &res)

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -456,10 +456,12 @@ func (client *BitbucketCloudClient) UnlabelPullRequest(ctx context.Context, owne
 	return errLabelsNotSupported
 }
 
+// UploadCodeScanning on Bitbucket cloud
 func (client *BitbucketCloudClient) UploadCodeScanning(ctx context.Context, owner string, repository string, branch string, scanResults string) (string, error) {
 	return "", errBitbucketCodeScanningNotSupported
 }
 
+// DownloadFileFromRepo on Bitbucket cloud
 func (client *BitbucketCloudClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
 	return nil, 0, errBitbucketDownloadFileFromRepoNotSupported
 }

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -393,6 +393,15 @@ func TestBitbucketCloud_CreateLabel(t *testing.T) {
 	assert.ErrorIs(t, err, errLabelsNotSupported)
 }
 
+func TestBitbucketCloudClient_DownloadFileFromRepo(t *testing.T) {
+	ctx := context.Background()
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
+	assert.NoError(t, err)
+
+	_, _, err = client.DownloadFileFromRepo(ctx, owner, repo1, branch1, "")
+	assert.ErrorIs(t, err, errBitbucketDownloadFileFromRepoNotSupported)
+}
+
 func TestBitbucketCloud_GetLabel(t *testing.T) {
 	ctx := context.Background()
 	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -7,6 +7,8 @@ import (
 var errLabelsNotSupported = errors.New("labels are not supported on Bitbucket")
 var errBitbucketCodeScanningNotSupported = errors.New("code scanning is not supported on Bitbucket")
 
+var errBitbucketDownloadFileFromRepoNotSupported = errors.New("download file from repo is currently not supported on Bitbucket")
+
 func getBitbucketCommitState(commitState CommitStatus) string {
 	switch commitState {
 	case Pass:

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -551,6 +551,10 @@ func (client *BitbucketServerClient) listProjects(bitbucketClient *bitbucketv1.D
 	return projects, nil
 }
 
+func (client *BitbucketServerClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
+	return nil, 0, errBitbucketDownloadFileFromRepoNotSupported
+}
+
 func createPaginationOptions(nextPageStart int) map[string]interface{} {
 	return map[string]interface{}{"start": nextPageStart}
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -551,6 +551,7 @@ func (client *BitbucketServerClient) listProjects(bitbucketClient *bitbucketv1.D
 	return projects, nil
 }
 
+// DownloadFileFromRepo on Bitbucket server
 func (client *BitbucketServerClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
 	return nil, 0, errBitbucketDownloadFileFromRepoNotSupported
 }

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -509,6 +509,14 @@ func TestBitbucketServer_UploadCodeScanning(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBitbucketServer_DownloadFileFromRepo(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, "", "unsupportedTest", createBitbucketServerHandler)
+	defer cleanUp()
+	_, _, err := client.DownloadFileFromRepo(ctx, owner, repo1, "", "")
+	assert.Error(t, err)
+}
+
 func createBitbucketServerHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(expectedStatusCode)

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -8,6 +8,7 @@ import (
 	"github.com/grokify/mogo/encoding/base64"
 	"github.com/jfrog/froggit-go/vcsutils"
 	"golang.org/x/oauth2"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -204,7 +205,6 @@ func (client *GitHubClient) DownloadRepository(ctx context.Context, owner, repos
 	if err != nil {
 		return err
 	}
-	req.Header.Add("Accept", "application/vnd.github.v3+json")
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return err
@@ -501,6 +501,27 @@ func (client *GitHubClient) UploadCodeScanning(ctx context.Context, owner, repos
 	}
 
 	return "", nil
+}
+
+// DownloadFileFromRepo on GitHub
+func (client *GitHubClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
+	ghClient, err := client.buildGithubClient(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	body, response, err := ghClient.Repositories.DownloadContents(ctx, owner, repository, path, &github.RepositoryContentGetOptions{Ref: branch})
+	if err != nil {
+		return nil, response.StatusCode, err
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, response.StatusCode, fmt.Errorf("expected %d status code while received %d status code", http.StatusOK, response.StatusCode)
+	}
+
+	bodyContent, err := io.ReadAll(body)
+	if err != nil {
+		return nil, response.StatusCode, err
+	}
+	return bodyContent, response.StatusCode, nil
 }
 
 func createGitHubHook(token, payloadURL string, webhookEvents ...vcsutils.WebhookEvent) *github.Hook {

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -216,9 +216,13 @@ func TestGitHubClient_DownloadFileFromRepository(t *testing.T) {
 	name := "hello-world"
 	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, &[]github.RepositoryContent{{DownloadURL: &downloadURL, Name: &name}}, "/repos/jfrog/repo-1/contents/?ref=branch-1", createGitHubHandler)
 	defer cleanUp()
-	_, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo1, branch1, "hello-world")
+	content, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo1, branch1, "hello-world")
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, statusCode)
+	assert.NotEmpty(t, content)
+
+	_, _, err = client.DownloadFileFromRepo(ctx, owner, repo1, branch1, "hello-bald")
+	assert.Error(t, err)
 
 	_, _, err = createBadGitHubClient(t).DownloadFileFromRepo(ctx, owner, repo1, branch1, "hello")
 	assert.Error(t, err)

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -210,6 +210,20 @@ func TestGitHubClient_DownloadRepository(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGitHubClient_DownloadFileFromRepository(t *testing.T) {
+	ctx := context.Background()
+	downloadURL := "https://jfrog.com"
+	name := "hello-world"
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, &[]github.RepositoryContent{{DownloadURL: &downloadURL, Name: &name}}, "/repos/jfrog/repo-1/contents/?ref=branch-1", createGitHubHandler)
+	defer cleanUp()
+	_, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo1, branch1, "hello-world")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+
+	_, _, err = createBadGitHubClient(t).DownloadFileFromRepo(ctx, owner, repo1, branch1, "hello")
+	assert.Error(t, err)
+}
+
 func TestGitHubClient_CreatePullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.PullRequest{}, "/repos/jfrog/repo-1/pulls", createGitHubHandler)

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -149,6 +149,18 @@ func TestGitLabClient_DownloadRepository(t *testing.T) {
 	assert.Equal(t, "README.md", fileinfo[0].Name())
 }
 
+func TestGitLabClient_DownloadFileFromRepo(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, gitlab.File{Content: "SGVsbG8gV29ybGQh"}, fmt.Sprintf("/api/v4/projects/%s/repository/files/hello-world?ref=branch-1", url.PathEscape(owner+"/"+repo1)), createGitLabHandler)
+	defer cleanUp()
+
+	content, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo1, branch1, "hello-world")
+	assert.NoError(t, err)
+	assert.Equal(t, statusCode, http.StatusOK)
+	expected := "Hello World!"
+	assert.Equal(t, expected, string(content))
+}
+
 func TestGitLabClient_CreatePullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, &gitlab.MergeRequest{}, fmt.Sprintf("/api/v4/projects/%s/merge_requests", url.PathEscape(owner+"/"+repo1)), createGitLabHandler)

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -180,6 +180,13 @@ type VcsClient interface {
 	// branch        - The name of the branch
 	// scan  		 - Code scanning analysis
 	UploadCodeScanning(ctx context.Context, owner, repository, branch, scanResults string) (string, error)
+
+	// DownloadFileFromRepo Downloads a file from path in a repository
+	// owner         - User or organization
+	// repository    - VCS repository name
+	// branch        - The name of the branch
+	// path  		 - The path to the requested file
+	DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error)
 }
 
 // CommitInfo contains the details of a commit


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
