### PR TITLE
Added DownloadFileFromRepository to Bitbucket Server

### DIFF
--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -553,7 +553,15 @@ func (client *BitbucketServerClient) listProjects(bitbucketClient *bitbucketv1.D
 
 // DownloadFileFromRepo on Bitbucket server
 func (client *BitbucketServerClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {
-	return nil, 0, errBitbucketDownloadFileFromRepoNotSupported
+	bitbucketClient, err := client.buildBitbucketClient(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	resp, err := bitbucketClient.GetContent_11(owner, repository, path, map[string]interface{}{"at": branch})
+	if err != nil {
+		return nil, 0, err
+	}
+	return resp.Payload, resp.StatusCode, err
 }
 
 func createPaginationOptions(nextPageStart int) map[string]interface{} {

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -519,7 +519,7 @@ func (client *GitHubClient) DownloadFileFromRepo(ctx context.Context, owner, rep
 		}
 	}()
 	if response != nil && response.StatusCode != http.StatusOK {
-		return nil, response.StatusCode, fmt.Errorf("expected %d status code while received %d status code", http.StatusOK, response.StatusCode)
+		return nil, response.StatusCode, fmt.Errorf("expected %d status code while received %d status code with error:\n%s", http.StatusOK, response.StatusCode, err)
 	}
 	if err != nil {
 		return nil, 0, err

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -210,7 +210,7 @@ func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, reposi
 }
 
 // ListOpenPullRequests on GitLab
-func (client *GitLabClient) ListOpenPullRequests(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
+func (client *GitLabClient) ListOpenPullRequests(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
 	openState := "open"
 	allScope := "all"
 	options := &gitlab.ListMergeRequestsOptions{
@@ -386,7 +386,7 @@ func (client *GitLabClient) UnlabelPullRequest(ctx context.Context, owner, repos
 	return err
 }
 
-func (client *GitLabClient) UploadCodeScanning(ctx context.Context, owner string, repository string, branch string, scanResults string) (string, error) {
+func (client *GitLabClient) UploadCodeScanning(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {
 	return "", errGitLabCodeScanningNotSupported
 }
 
@@ -394,7 +394,7 @@ func (client *GitLabClient) UploadCodeScanning(ctx context.Context, owner string
 func (client *GitLabClient) DownloadFileFromRepo(_ context.Context, owner, repository, branch, path string) ([]byte, int, error) {
 	file, response, err := client.glClient.RepositoryFiles.GetFile(getProjectID(owner, repository), path, &gitlab.GetFileOptions{Ref: &branch})
 	if response != nil && response.StatusCode != http.StatusOK {
-		return nil, response.StatusCode, fmt.Errorf("expected %d status code while received %d status code", http.StatusOK, response.StatusCode)
+		return nil, response.StatusCode, fmt.Errorf("expected %d status code while received %d status code with error:\n%s", http.StatusOK, response.StatusCode, err)
 	}
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
