### PR TITLE
Add repository visibility to the repository info

### DIFF
--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -405,7 +405,7 @@ func (client *BitbucketCloudClient) GetRepositoryInfo(ctx context.Context, owner
 			info.SSH = link.HRef
 		}
 	}
-	return RepositoryInfo{CloneInfo: info}, nil
+	return RepositoryInfo{RepositoryVisibility: getBitbucketCloudRepositoryVisibility(repo), CloneInfo: info}, nil
 }
 
 // GetCommitBySha on Bitbucket cloud
@@ -658,4 +658,11 @@ func mapBitbucketCloudPullRequestToPullRequestInfo(parsedPullRequests *pullReque
 		}
 	}
 	return pullRequests
+}
+
+func getBitbucketCloudRepositoryVisibility(repo *bitbucket.Repository) RepositoryVisibility {
+	if repo.Is_private {
+		return Private
+	}
+	return Public
 }

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -375,6 +375,7 @@ func TestBitbucketCloud_GetRepositoryInfo(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t,
 		RepositoryInfo{
+			RepositoryVisibility: Public,
 			CloneInfo: CloneInfo{
 				HTTP: "https://bitbucket.org/jfrog/jfrog-setup-cli.git",
 				SSH:  "git@bitbucket.org:jfrog/jfrog-setup-cli.git",
@@ -427,6 +428,11 @@ func TestBitbucketCloud_UnlabelPullRequest(t *testing.T) {
 
 	err = client.UnlabelPullRequest(ctx, owner, repo1, labelName, 1)
 	assert.ErrorIs(t, err, errLabelsNotSupported)
+}
+
+func TestBitbucketCloud_getRepositoryVisibility(t *testing.T) {
+	assert.Equal(t, Private, getBitbucketCloudRepositoryVisibility(&bitbucket.Repository{Is_private: true}))
+	assert.Equal(t, Public, getBitbucketCloudRepositoryVisibility(&bitbucket.Repository{Is_private: false}))
 }
 
 func createBitbucketCloudHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -455,6 +455,7 @@ func (client *BitbucketServerClient) GetRepositoryInfo(ctx context.Context, owne
 				HRef string `mapstructure:"href"`
 			} `mapstructure:"clone"`
 		} `mapstructure:"links"`
+		Public bool `mapstructure:"public"`
 	}{}
 
 	if err := mapstructure.Decode(repo.Values, &holder); err != nil {
@@ -471,7 +472,7 @@ func (client *BitbucketServerClient) GetRepositoryInfo(ctx context.Context, owne
 		}
 	}
 
-	return RepositoryInfo{CloneInfo: info}, nil
+	return RepositoryInfo{RepositoryVisibility: getBitbucketServerRepositoryVisibility(holder.Public), CloneInfo: info}, nil
 }
 
 // GetCommitBySha on Bitbucket server
@@ -634,4 +635,11 @@ func (client *BitbucketServerClient) mapBitbucketServerCommitToCommitInfo(commit
 
 func (client *BitbucketServerClient) UploadCodeScanning(ctx context.Context, owner string, repository string, branch string, scanResults string) (string, error) {
 	return "", errBitbucketCodeScanningNotSupported
+}
+
+func getBitbucketServerRepositoryVisibility(public bool) RepositoryVisibility {
+	if public {
+		return Public
+	}
+	return Private
 }

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -398,6 +398,7 @@ func TestBitbucketServer_GetRepositoryInfo(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t,
 			RepositoryInfo{
+				RepositoryVisibility: Public,
 				CloneInfo: CloneInfo{
 					HTTP: "https://bitbucket.org/jfrog/repo-1.git",
 					SSH:  "ssh://git@bitbucket.org:jfrog/repo-1.git",
@@ -529,6 +530,11 @@ func TestBitbucketServer_DownloadFileFromRepo(t *testing.T) {
 	defer cleanUp()
 	_, _, err = client.DownloadFileFromRepo(ctx, owner, repo1, branch1, "bad-test")
 	assert.Error(t, err)
+}
+
+func TestBitbucketServer_getRepositoryVisibility(t *testing.T) {
+	assert.Equal(t, Public, getBitbucketServerRepositoryVisibility(true))
+	assert.Equal(t, Private, getBitbucketServerRepositoryVisibility(false))
 }
 
 func createBitbucketServerHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {

--- a/vcsclient/common_test.go
+++ b/vcsclient/common_test.go
@@ -19,12 +19,12 @@ const (
 )
 
 var (
-	repo1     = "repo-1"
-	repo2     = "repo-2"
-	username  = "frogger"
-	branch1   = "branch-1"
-	branch2   = "branch-2"
-	labelName = "🚀 label-name"
+	repo1      = "repo-1"
+	repo2      = "repo-2"
+	username   = "frogger"
+	branch1    = "branch-1"
+	branch2    = "branch-2"
+	labelName  = "🚀 label-name"
 )
 
 type createHandlerFunc func(t *testing.T, expectedUri string, response []byte, expectedStatusCode int) http.HandlerFunc

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/google/go-github/v45/github"
-	"github.com/grokify/mogo/encoding/base64"
-	"github.com/jfrog/froggit-go/vcsutils"
-	"golang.org/x/oauth2"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/google/go-github/v45/github"
+	"github.com/grokify/mogo/encoding/base64"
+	"github.com/jfrog/froggit-go/vcsutils"
+	"golang.org/x/oauth2"
 )
 
 // GitHubClient API version 3
@@ -340,7 +341,7 @@ func (client *GitHubClient) GetRepositoryInfo(ctx context.Context, owner, reposi
 	if err != nil {
 		return RepositoryInfo{}, err
 	}
-	return RepositoryInfo{CloneInfo: CloneInfo{HTTP: repo.GetCloneURL(), SSH: repo.GetSSHURL()}}, nil
+	return RepositoryInfo{RepositoryVisibility: getGitHubRepositoryVisibility(repo), CloneInfo: CloneInfo{HTTP: repo.GetCloneURL(), SSH: repo.GetSSHURL()}}, nil
 }
 
 // GetCommitBySha on GitHub
@@ -555,6 +556,17 @@ func getGitHubWebhookEvents(webhookEvents ...vcsutils.WebhookEvent) []string {
 		}
 	}
 	return events
+}
+
+func getGitHubRepositoryVisibility(repo *github.Repository) RepositoryVisibility {
+	switch *repo.Visibility {
+	case "public":
+		return Public
+	case "internal":
+		return Internal
+	default:
+		return Private
+	}
 }
 
 func getGitHubCommitState(commitState CommitStatus) string {

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -178,6 +178,15 @@ func TestGitHubClient_CreateCommitStatus(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGitHubClient_getRepositoryVisibility(t *testing.T) {
+	visibility := "public"
+	assert.Equal(t, Public, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))
+	visibility = "internal"
+	assert.Equal(t, Internal, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))
+	visibility = "private"
+	assert.Equal(t, Private, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))
+}
+
 func TestGitHubClient_getGitHubCommitState(t *testing.T) {
 	assert.Equal(t, "success", getGitHubCommitState(Pass))
 	assert.Equal(t, "failure", getGitHubCommitState(Fail))
@@ -426,7 +435,8 @@ func TestGitHubClient_GetRepositoryInfo(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t,
 		RepositoryInfo{
-			CloneInfo: CloneInfo{HTTP: "https://github.com/octocat/Hello-World.git", SSH: "git@github.com:octocat/Hello-World.git"},
+			RepositoryVisibility: Public,
+			CloneInfo:            CloneInfo{HTTP: "https://github.com/octocat/Hello-World.git", SSH: "git@github.com:octocat/Hello-World.git"},
 		},
 		info,
 	)

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -297,7 +297,7 @@ func (client *GitLabClient) GetRepositoryInfo(ctx context.Context, owner, reposi
 		return RepositoryInfo{}, err
 	}
 
-	return RepositoryInfo{RepositoryVisibility: getProjectVisibility(project), CloneInfo: CloneInfo{HTTP: project.HTTPURLToRepo, SSH: project.SSHURLToRepo}}, nil
+	return RepositoryInfo{RepositoryVisibility: getGitLabProjectVisibility(project), CloneInfo: CloneInfo{HTTP: project.HTTPURLToRepo, SSH: project.SSHURLToRepo}}, nil
 }
 
 // GetCommitBySha on GitLab
@@ -426,7 +426,7 @@ func createProjectHook(branch string, payloadURL string, webhookEvents ...vcsuti
 	return options
 }
 
-func getProjectVisibility(project *gitlab.Project) RepositoryVisibility {
+func getGitLabProjectVisibility(project *gitlab.Project) RepositoryVisibility {
 	switch project.Visibility {
 	case gitlab.PublicVisibility:
 		return Public

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -297,7 +297,7 @@ func (client *GitLabClient) GetRepositoryInfo(ctx context.Context, owner, reposi
 		return RepositoryInfo{}, err
 	}
 
-	return RepositoryInfo{CloneInfo: CloneInfo{HTTP: project.HTTPURLToRepo, SSH: project.SSHURLToRepo}}, nil
+	return RepositoryInfo{RepositoryVisibility: getProjectVisibility(project), CloneInfo: CloneInfo{HTTP: project.HTTPURLToRepo, SSH: project.SSHURLToRepo}}, nil
 }
 
 // GetCommitBySha on GitLab
@@ -424,6 +424,17 @@ func createProjectHook(branch string, payloadURL string, webhookEvents ...vcsuti
 		}
 	}
 	return options
+}
+
+func getProjectVisibility(project *gitlab.Project) RepositoryVisibility {
+	switch project.Visibility {
+	case gitlab.PublicVisibility:
+		return Public
+	case gitlab.InternalVisibility:
+		return Internal
+	default:
+		return Private
+	}
 }
 
 func getGitLabCommitState(commitState CommitStatus) string {

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -332,9 +332,11 @@ func TestGitLabClient_GetRepositoryInfo(t *testing.T) {
 	result, err := client.GetRepositoryInfo(ctx, "diaspora", "diaspora-project-site")
 	require.NoError(t, err)
 	require.Equal(t,
-		RepositoryInfo{CloneInfo: CloneInfo{
-			HTTP: "http://example.com/diaspora/diaspora-project-site.git",
-			SSH:  "git@example.com:diaspora/diaspora-project-site.git"},
+		RepositoryInfo{
+			RepositoryVisibility: Private,
+			CloneInfo: CloneInfo{
+				HTTP: "http://example.com/diaspora/diaspora-project-site.git",
+				SSH:  "git@example.com:diaspora/diaspora-project-site.git"},
 		},
 		result,
 	)

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -386,6 +386,12 @@ func TestGitLabClient_GetCommitByShaNotFound(t *testing.T) {
 	assert.Empty(t, result)
 }
 
+func TestGitLabClient_getGitLabProjectVisibility(t *testing.T) {
+	assert.Equal(t, Public, getGitLabProjectVisibility(&gitlab.Project{Visibility: gitlab.PublicVisibility}))
+	assert.Equal(t, Internal, getGitLabProjectVisibility(&gitlab.Project{Visibility: gitlab.InternalVisibility}))
+	assert.Equal(t, Private, getGitLabProjectVisibility(&gitlab.Project{Visibility: gitlab.PrivateVisibility}))
+}
+
 func TestGitlabClient_getGitlabCommitState(t *testing.T) {
 	assert.Equal(t, "success", getGitLabCommitState(Pass))
 	assert.Equal(t, "failed", getGitLabCommitState(Fail))

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -33,6 +33,18 @@ const (
 	ReadWrite
 )
 
+// RepositoryVisibility the visibility level of the repository
+type RepositoryVisibility int
+
+const (
+	// Open to public
+	Public RepositoryVisibility = iota
+	// Open to organization
+	Internal
+	// Open to user
+	Private
+)
+
 // VcsInfo is the connection details of the VcsClient to communicate with the server
 type VcsInfo struct {
 	APIEndpoint string
@@ -226,7 +238,8 @@ type BranchInfo struct {
 
 // RepositoryInfo contains general information about repository.
 type RepositoryInfo struct {
-	CloneInfo CloneInfo
+	CloneInfo            CloneInfo
+	RepositoryVisibility RepositoryVisibility
 }
 
 // CloneInfo contains URLs that can be used to clone the repository.


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
