### PR TITLE
Add GetModifiedFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
         - [List Pull Request Comments](#list-pull-request-comments)
       - [Get Latest Commit](#get-latest-commit)
       - [Get Commit By SHA](#get-commit-by-sha)
+      - [Get List of Modified Files](#get-list-of-modified-files)
       - [Add Public SSH Key](#add-public-ssh-key)
       - [Get Repository Info](#get-repository-info)
       - [Get Repository Environment Info](#get-repository-environment-info)
@@ -386,6 +387,27 @@ sha := "abcdef0123abcdef4567abcdef8987abcdef6543"
 
 // Commit information of requested commit
 commitInfo, err := client.GetCommitBySha(ctx, owner, repository, sha)
+```
+
+#### Get List of Modified Files
+
+The `refBefore...refAfter` syntax is used.
+More about it can be found at [Commit Ranges](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection) Git
+documentation.
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// SHA-1 hash of the commit or tag or a branch name
+refBefore := "abcdef0123abcdef4567abcdef8987abcdef6543"
+// SHA-1 hash of the commit or tag or a branch name
+refAfter := "main"
+
+filePaths, err := client.GetModifiedFiles(ctx, owner, repository, refBefore, refAfter)
 ```
 
 #### Add Public SSH Key

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,11 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/google/uuid v1.3.0
 	github.com/grokify/mogo v0.40.4
+	github.com/jfrog/gofrog v1.2.5
 	github.com/ktrysmt/go-bitbucket v0.9.32
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	github.com/mitchellh/mapstructure v1.4.3
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.0
 	github.com/xanzy/go-gitlab v0.52.2
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 )

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jfrog/gofrog v1.2.5 h1:jCgJC0iGQ8bU7jCC+YEFJTNINyngApIrhd8BjZAVRIE=
+github.com/jfrog/gofrog v1.2.5/go.mod h1:o00tSRff6IapTgaCMuX1Cs9MH08Y1JqnsKgRtx91Gc4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
@@ -198,11 +200,15 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/xanzy/go-gitlab v0.52.2 h1:gkgg1z4ON70sphibtD86Bfmt1qV3mZ0pU0CBBCFAEvQ=
 github.com/xanzy/go-gitlab v0.52.2/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -390,7 +390,7 @@ func TestAzureReposClient_GetModifiedFiles(t *testing.T) {
 		client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, response, expectedURI, createAzureReposHandler)
 		defer cleanUp()
 
-		actual, err := client.(*AzureReposClient).GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
+		actual, err := client.GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
 		require.NoError(t, err)
 		assert.Equal(t, []string{
 			"CustomerAddressModule/CustomerAddressModule.sln",
@@ -438,7 +438,7 @@ func TestAzureReposClient_GetModifiedFiles(t *testing.T) {
 		)
 		defer cleanUp()
 
-		_, err := client.(*AzureReposClient).GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
+		_, err := client.GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
 		require.EqualError(t, err, "null")
 	})
 }

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
@@ -377,6 +378,69 @@ func TestGetUnsupportedInAzureError(t *testing.T) {
 	functionName := "foo"
 	assert.Error(t, getUnsupportedInAzureError(functionName))
 	assert.Equal(t, "foo is currently not supported for Azure Repos", getUnsupportedInAzureError(functionName).Error())
+}
+
+func TestAzureReposClient_GetModifiedFiles(t *testing.T) {
+	ctx := context.Background()
+	t.Run("ok", func(t *testing.T) {
+		response, err := os.ReadFile(filepath.Join("testdata", "azurerepos", "compare_commits.json"))
+		require.NoError(t, err)
+
+		const expectedURI = "/_apis/ResourceAreas?%24skip=0&%24top=100&baseVersion=sha-1&diffCommonCommit=true&targetVersion=sha-2"
+		client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, response, expectedURI, createAzureReposHandler)
+		defer cleanUp()
+
+		actual, err := client.(*AzureReposClient).GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
+		require.NoError(t, err)
+		assert.Equal(t, []string{
+			"CustomerAddressModule/CustomerAddressModule.sln",
+			"CustomerAddressModule/CustomerAddressModule/App.config",
+			"CustomerAddressModule/CustomerAddressModule/CustomerAddressModule.csproj",
+			"CustomerAddressModule/CustomerAddressModule/Form1.Designer.cs",
+			"CustomerAddressModule/CustomerAddressModule/Form1.cs",
+			"CustomerAddressModule/CustomerAddressModule/Form1.resx",
+			"CustomerAddressModule/CustomerAddressModule/Program.cs",
+			"CustomerAddressModule/CustomerAddressModule/Properties/AssemblyInfo.cs",
+			"CustomerAddressModule/CustomerAddressModule/Properties/Resources.Designer.cs",
+			"CustomerAddressModule/CustomerAddressModule/Properties/Resources.resx",
+			"CustomerAddressModule/CustomerAddressModule/Properties/Settings.Designer.cs",
+			"CustomerAddressModule/CustomerAddressModule/Properties/Settings.settings",
+			"HelloWorld/.classpath",
+			"HelloWorld/.project",
+			"HelloWorld/build.xml",
+			"HelloWorld/dist/lib/MyProject-20140210.jar",
+			"HelloWorld/src/HelloWorld.java",
+			"MyWebSite/MyWebSite/Views/Home/_Register.cshtml",
+			"MyWebSite/MyWebSite/Web.config",
+		}, actual)
+	})
+
+	t.Run("validation fails", func(t *testing.T) {
+		client := AzureReposClient{}
+		_, err := client.GetModifiedFiles(ctx, owner, "", "sha-1", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'repository' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, repo1, "", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'refBefore' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "")
+		require.Equal(t, errors.New("validation failed: required parameter 'refAfter' is missing"), err)
+	})
+
+	t.Run("failed request", func(t *testing.T) {
+		const expectedURI = "/_apis/ResourceAreas?%24skip=0&%24top=100&baseVersion=sha-1&diffCommonCommit=true&targetVersion=sha-2"
+		client, cleanUp := createServerAndClientReturningStatus(
+			t,
+			vcsutils.AzureRepos,
+			true,
+			nil,
+			expectedURI,
+			http.StatusInternalServerError,
+			createAzureReposHandler,
+		)
+		defer cleanUp()
+
+		_, err := client.(*AzureReposClient).GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
+		require.EqualError(t, err, "null")
+	})
 }
 
 func createAzureReposHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -457,7 +457,7 @@ func TestBitbucketCloudClient_GetModifiedFiles(t *testing.T) {
 			createBitbucketCloudHandler)
 		defer cleanUp()
 
-		res, err := client.(*BitbucketCloudClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		res, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		require.NoError(t, err)
 		require.Equal(t, []string{"setup.py", "some/full.py"}, res)
 	})
@@ -485,7 +485,7 @@ func TestBitbucketCloudClient_GetModifiedFiles(t *testing.T) {
 			createBitbucketCloudHandler,
 		)
 		defer cleanUp()
-		_, err := client.(*BitbucketCloudClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		_, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		require.Equal(t, errors.New("500 Internal Server Error"), err)
 	})
 }

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -566,7 +566,7 @@ func TestBitbucketServerClient_GetModifiedFiles(t *testing.T) {
 		)
 		defer closeServer()
 
-		actual, err := client.(*BitbucketServerClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		actual, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		require.NoError(t, err)
 		assert.Equal(t, []string{"path/to/file.txt", "path/to/other_file.txt", "path/to/other_file2.txt"}, actual)
 	})
@@ -594,7 +594,7 @@ func TestBitbucketServerClient_GetModifiedFiles(t *testing.T) {
 			createBitbucketServerHandler,
 		)
 		defer cleanUp()
-		_, err := client.(*BitbucketServerClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		_, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		require.Equal(t, errors.New("Status: 500 Internal Server Error, Body: null"), err)
 	})
 }

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -635,7 +635,7 @@ func TestGitHubClient_GetModifiedFiles(t *testing.T) {
 		)
 		defer cleanUp()
 
-		fileNames, err := client.(*GitHubClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		fileNames, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		assert.NoError(t, err)
 		assert.Equal(t, []string{
 			"README.md",
@@ -683,7 +683,7 @@ func TestGitHubClient_GetModifiedFiles(t *testing.T) {
 			createGitHubHandler,
 		)
 		defer cleanUp()
-		_, err := client.(*GitHubClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		_, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "repos/jfrog/repo-1/compare/sha-1...sha-2?per_page=1: 500  []")
 	})

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -3,6 +3,7 @@ package vcsclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -615,6 +616,77 @@ func TestGitHubClient_ExtractGitHubEnvironmentReviewers(t *testing.T) {
 	actualReviewers, err := extractGitHubEnvironmentReviewers(environment)
 	assert.NoError(t, err)
 	assert.Equal(t, []string{reviewer1, reviewer2}, actualReviewers)
+}
+
+func TestGitHubClient_GetModifiedFiles(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ok", func(t *testing.T) {
+		response, err := os.ReadFile(filepath.Join("testdata", "github", "compare_commits.json"))
+		assert.NoError(t, err)
+
+		client, cleanUp := createServerAndClient(
+			t,
+			vcsutils.GitHub,
+			false,
+			response,
+			"/repos/jfrog/repo-1/compare/sha-1...sha-2?per_page=1",
+			createGitHubHandler,
+		)
+		defer cleanUp()
+
+		fileNames, err := client.(*GitHubClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		assert.NoError(t, err)
+		assert.Equal(t, []string{
+			"README.md",
+			"vcsclient/azurerepos.go",
+			"vcsclient/azurerepos_test.go",
+			"vcsclient/bitbucketcloud.go",
+			"vcsclient/bitbucketcloud_test.go",
+			"vcsclient/bitbucketcommon.go",
+			"vcsclient/bitbucketserver.go",
+			"vcsclient/bitbucketserver_test.go",
+			"vcsclient/common_test.go",
+			"vcsclient/github.go",
+			"vcsclient/github_test.go",
+			"vcsclient/gitlab.go",
+			"vcsclient/gitlab_test.go",
+			"vcsclient/gitlabcommon.go",
+			"vcsclient/testdata/github/repository_environment_response.json",
+			"vcsclient/vcsclient.go",
+			"vcsclient/vcsclient_old.go",
+		},
+			fileNames,
+		)
+	})
+
+	t.Run("validation fails", func(t *testing.T) {
+		client := GitHubClient{}
+		_, err := client.GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'owner' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, "", "sha-1", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'repository' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, repo1, "", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'refBefore' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "")
+		require.Equal(t, errors.New("validation failed: required parameter 'refAfter' is missing"), err)
+	})
+
+	t.Run("failed request", func(t *testing.T) {
+		client, cleanUp := createServerAndClientReturningStatus(
+			t,
+			vcsutils.GitHub,
+			true,
+			nil,
+			"/repos/jfrog/repo-1/compare/sha-1...sha-2?per_page=1",
+			http.StatusInternalServerError,
+			createGitHubHandler,
+		)
+		defer cleanUp()
+		_, err := client.(*GitHubClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "repos/jfrog/repo-1/compare/sha-1...sha-2?per_page=1: 500  []")
+	})
 }
 
 func createBadGitHubClient(t *testing.T) VcsClient {

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -488,7 +488,7 @@ func TestGitLabClient_GetModifiedFiles(t *testing.T) {
 		)
 		defer cleanUp()
 
-		fileNames, err := client.(*GitLabClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		fileNames, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		require.NoError(t, err)
 		require.Equal(t, []string{
 			"doc/user/project/integrations/gitlab_slack_application.md",
@@ -521,7 +521,7 @@ func TestGitLabClient_GetModifiedFiles(t *testing.T) {
 			createGitLabHandler,
 		)
 		defer cleanUp()
-		_, err := client.(*GitLabClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		_, err := client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "api/v4/projects/jfrog/repo-1/repository/compare: 500 failed to parse unexpected error type: <nil>")
 	})

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -3,6 +3,7 @@ package vcsclient
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -469,6 +470,61 @@ func TestGitlabClient_GetRepositoryEnvironmentInfo(t *testing.T) {
 
 	_, err := client.GetRepositoryEnvironmentInfo(ctx, owner, repo1, envName)
 	assert.ErrorIs(t, err, errGitLabGetRepoEnvironmentInfoNotSupported)
+}
+
+func TestGitLabClient_GetModifiedFiles(t *testing.T) {
+	ctx := context.Background()
+	t.Run("ok", func(t *testing.T) {
+		response, err := os.ReadFile(filepath.Join("testdata", "gitlab", "compare_commits.json"))
+		require.NoError(t, err)
+
+		client, cleanUp := createServerAndClient(
+			t,
+			vcsutils.GitLab,
+			true,
+			response,
+			fmt.Sprintf("/api/v4/projects/%s/repository/compare?from=sha-1&to=sha-2", url.PathEscape(owner+"/"+repo1)),
+			createGitLabHandler,
+		)
+		defer cleanUp()
+
+		fileNames, err := client.(*GitLabClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		require.NoError(t, err)
+		require.Equal(t, []string{
+			"doc/user/project/integrations/gitlab_slack_application.md",
+			"doc/user/project/integrations/slack.md",
+			"doc/user/project/integrations/slack_slash_commands.md",
+			"doc/user/project/integrations/slack_slash_commands_2.md",
+		}, fileNames)
+	})
+
+	t.Run("validation fails", func(t *testing.T) {
+		client := GitLabClient{}
+		_, err := client.GetModifiedFiles(ctx, "", repo1, "sha-1", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'owner' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, "", "sha-1", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'repository' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, repo1, "", "sha-2")
+		require.Equal(t, errors.New("validation failed: required parameter 'refBefore' is missing"), err)
+		_, err = client.GetModifiedFiles(ctx, owner, repo1, "sha-1", "")
+		require.Equal(t, errors.New("validation failed: required parameter 'refAfter' is missing"), err)
+	})
+
+	t.Run("failed request", func(t *testing.T) {
+		client, cleanUp := createServerAndClientReturningStatus(
+			t,
+			vcsutils.GitLab,
+			true,
+			nil,
+			"/api/v4/projects/jfrog%2Frepo-1/repository/compare?from=sha-1&to=sha-2",
+			http.StatusInternalServerError,
+			createGitLabHandler,
+		)
+		defer cleanUp()
+		_, err := client.(*GitLabClient).GetModifiedFiles(ctx, owner, repo1, "sha-1", "sha-2")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "api/v4/projects/jfrog/repo-1/repository/compare: 500 failed to parse unexpected error type: <nil>")
+	})
 }
 
 func createGitLabHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {

--- a/vcsclient/testdata/azurerepos/compare_commits.json
+++ b/vcsclient/testdata/azurerepos/compare_commits.json
@@ -1,0 +1,293 @@
+{
+  "allChangesIncluded": true,
+  "changeCounts": {
+    "Add": 24,
+    "Edit": 6
+  },
+  "changes": [
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule.sln",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule.sln?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/App.config",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/App.config?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/CustomerAddressModule.csproj",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/CustomerAddressModule.csproj?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Form1.Designer.cs",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Form1.Designer.cs?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Form1.cs",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Form1.cs?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Form1.resx",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Form1.resx?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Program.cs",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Program.cs?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Properties",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Properties?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Properties/AssemblyInfo.cs",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Properties/AssemblyInfo.cs?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Properties/Resources.Designer.cs",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Properties/Resources.Designer.cs?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Properties/Resources.resx",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Properties/Resources.resx?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Properties/Settings.Designer.cs",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Properties/Settings.Designer.cs?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/CustomerAddressModule/CustomerAddressModule/Properties/Settings.settings",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/CustomerAddressModule/CustomerAddressModule/Properties/Settings.settings?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/.classpath",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/.classpath?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/.project",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/.project?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/build.xml",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/build.xml?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/dist",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/dist?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/dist/lib",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/dist/lib?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/dist/lib/MyProject-20140210.jar",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/dist/lib/MyProject-20140210.jar?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/src",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/src?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/HelloWorld/src/HelloWorld.java",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/HelloWorld/src/HelloWorld.java?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "add"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/MyWebSite",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/MyWebSite?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "edit"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/MyWebSite/MyWebSite",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/MyWebSite/MyWebSite?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "edit"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/MyWebSite/MyWebSite/Views",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/MyWebSite/MyWebSite/Views?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "edit"
+    },
+    {
+      "item": {
+        "gitObjectType": "tree",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/MyWebSite/MyWebSite/Views/Home",
+        "isFolder": true,
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/MyWebSite/MyWebSite/Views/Home?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "edit"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/MyWebSite/MyWebSite/Views/Home/_Register.cshtml",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/MyWebSite/MyWebSite/Views/Home/_Register.cshtml?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "edit"
+    },
+    {
+      "item": {
+        "gitObjectType": "blob",
+        "commitId": "23d0bc5b128a10056dc68afece360d8a0fabb014",
+        "path": "/MyWebSite/MyWebSite/Web.config",
+        "url": "https://dev.azure.com/fabrikam/c34d5807-1734-4541-ad1c-d16e9ac1faca/_apis/git/repositories/278d5cd2-584d-4b63-824a-2ba458937249/items/MyWebSite/MyWebSite/Web.config?versionType=Commit&version=23d0bc5b128a10056dc68afece360d8a0fabb014"
+      },
+      "changeType": "edit"
+    }
+  ],
+  "commonCommit": "be67f8871a4d2c75f13a51c1d3c30ac0d74d4ef4",
+  "aheadCount": 17,
+  "behindCount": 1
+}

--- a/vcsclient/testdata/azurerepos/resourcesResponse.json
+++ b/vcsclient/testdata/azurerepos/resourcesResponse.json
@@ -69,6 +69,16 @@
       "minVersion": "3.2",
       "maxVersion": "7.1",
       "releasedVersion": "0.0"
+    },
+    {
+      "id": "615588d5-c0c7-4b88-88f8-e625306446e8",
+      "area": "Location",
+      "resourceName": "ResourceAreas",
+      "routeTemplate": "_apis/{resource}/{areaId}",
+      "resourceVersion": 1,
+      "minVersion": "3.2",
+      "maxVersion": "7.1",
+      "releasedVersion": "0.0"
     }
   ],
   "count": 2

--- a/vcsclient/testdata/bitbucketcloud/compare_commits.json
+++ b/vcsclient/testdata/bitbucketcloud/compare_commits.json
@@ -1,0 +1,85 @@
+{
+  "pagelen": 500,
+  "values": [
+    {
+      "type": "diffstat",
+      "status": "modified",
+      "lines_removed": 1,
+      "lines_added": 2,
+      "old": {
+        "path": "setup.py",
+        "escaped_path": "setup.py",
+        "type": "commit_file",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucket/geordi/src/e1749643d655d7c7014001a6c0f58abaf42ad850/setup.py"
+          }
+        }
+      },
+      "new": {
+        "path": "setup.py",
+        "escaped_path": "setup.py",
+        "type": "commit_file",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucket/geordi/src/d222fa235229c55dad20b190b0b571adf737d5a6/setup.py"
+          }
+        }
+      }
+    },
+    {
+      "type": "diffstat",
+      "status": "modified",
+      "lines_removed": 1,
+      "lines_added": 2,
+      "old": {
+        "path": "some/full.py",
+        "escaped_path": "some%2Ffull.py",
+        "type": "commit_file",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucket/geordi/src/e1749643d655d7c7054001a6c0f58abaf42ad850/some%2Ffull.py"
+          }
+        }
+      },
+      "new": {
+        "path": "some/full.py",
+        "escaped_path": "some%2Ffull.py",
+        "type": "commit_file",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucket/geordi/src/d222fa23522dc55dad20b190b0b571adf737d5a6/some%2Ffull.py"
+          }
+        }
+      }
+    },
+    {
+      "type": "diffstat",
+      "status": "modified",
+      "lines_removed": 1,
+      "lines_added": 2,
+      "old": {
+        "path": "some/full.py",
+        "escaped_path": "some%2Ffull.py",
+        "type": "commit_file",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucket/geordi/src/e1749643d655d7c7054001a6c0f58abaf42ad850/some%2Ffull.py"
+          }
+        }
+      },
+      "new": {
+        "path": "some/full.py",
+        "escaped_path": "some%2Ffull.py",
+        "type": "commit_file",
+        "links": {
+          "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucket/geordi/src/d222fa23522dc55dad20b190b0b571adf737d5a6/some%2Ffull.py"
+          }
+        }
+      }
+    }
+  ],
+  "page": 1,
+  "size": 2
+}

--- a/vcsclient/testdata/bitbucketserver/compare_commits.json
+++ b/vcsclient/testdata/bitbucketserver/compare_commits.json
@@ -1,0 +1,219 @@
+{
+  "diffs": [
+    {
+      "source": {
+        "components": [
+          "path",
+          "to",
+          "file.txt"
+        ],
+        "parent": "path/to",
+        "name": "file.txt",
+        "extension": "txt",
+        "toString": "path/to/file.txt"
+      },
+      "destination": {
+        "components": [
+          "path",
+          "to",
+          "file.txt"
+        ],
+        "parent": "path/to",
+        "name": "file.txt",
+        "extension": "txt",
+        "toString": "path/to/file.txt"
+      },
+      "hunks": [
+        {
+          "sourceLine": 1,
+          "sourceSpan": 1,
+          "destinationLine": 1,
+          "destinationSpan": 2,
+          "segments": [
+            {
+              "type": "REMOVED",
+              "lines": [
+                {
+                  "destination": 1,
+                  "source": 1,
+                  "line": "import sys",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "destination": 1,
+                  "source": 2,
+                  "line": "import re",
+                  "truncated": false
+                },
+                {
+                  "destination": 2,
+                  "source": 3,
+                  "line": "import os",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        }
+      ],
+      "truncated": "true",
+      "contextLines": "10",
+      "fromHash": "a0f224fd7bd5f28ea5a752d41b9c9f6372fc6d9e",
+      "toHash": "dc93f22caadcde35daf5cc2cd65d2738c87e31ca",
+      "whiteSpace": "SHOW"
+    },
+    {
+      "source": {
+        "components": [
+          "path",
+          "to",
+          "other_file.txt"
+        ],
+        "parent": "path/to",
+        "name": "other_file.txt",
+        "extension": "txt",
+        "toString": "path/to/other_file.txt"
+      },
+      "destination": {
+        "components": [
+          "path",
+          "to",
+          "other_file.txt"
+        ],
+        "parent": "path/to",
+        "name": "other_file.txt",
+        "extension": "txt",
+        "toString": "path/to/other_file.txt"
+      },
+      "hunks": [
+        {
+          "sourceLine": 1,
+          "sourceSpan": 1,
+          "destinationLine": 1,
+          "destinationSpan": 2,
+          "segments": [
+            {
+              "type": "REMOVED",
+              "lines": [
+                {
+                  "destination": 1,
+                  "source": 1,
+                  "line": "import sys",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "destination": 1,
+                  "source": 2,
+                  "line": "import re",
+                  "truncated": false
+                },
+                {
+                  "destination": 2,
+                  "source": 3,
+                  "line": "import os",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        }
+      ],
+      "truncated": "true",
+      "contextLines": "10",
+      "fromHash": "a0f224fd7bd5f28ea5a752d41b9c9f6372fc6d9e",
+      "toHash": "dc93f22caadcde35daf5cc2cd65d2738c87e31ca",
+      "whiteSpace": "SHOW"
+    },
+    {
+      "source": {
+        "components": [
+          "path",
+          "to",
+          "other_file.txt"
+        ],
+        "parent": "path/to",
+        "name": "other_file.txt",
+        "extension": "txt",
+        "toString": "path/to/other_file.txt"
+      },
+      "destination": {
+        "components": [
+          "path",
+          "to",
+          "other_file2.txt"
+        ],
+        "parent": "path/to",
+        "name": "other_file2.txt",
+        "extension": "txt",
+        "toString": "path/to/other_file2.txt"
+      },
+      "hunks": [
+        {
+          "sourceLine": 1,
+          "sourceSpan": 1,
+          "destinationLine": 1,
+          "destinationSpan": 2,
+          "segments": [
+            {
+              "type": "REMOVED",
+              "lines": [
+                {
+                  "destination": 1,
+                  "source": 1,
+                  "line": "import sys",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            },
+            {
+              "type": "ADDED",
+              "lines": [
+                {
+                  "destination": 1,
+                  "source": 2,
+                  "line": "import re",
+                  "truncated": false
+                },
+                {
+                  "destination": 2,
+                  "source": 3,
+                  "line": "import os",
+                  "truncated": false
+                }
+              ],
+              "truncated": false
+            }
+          ],
+          "truncated": false
+        }
+      ],
+      "truncated": "true",
+      "contextLines": "10",
+      "fromHash": "a0f224fd7bd5f28ea5a752d41b9c9f6372fc6d9e",
+      "toHash": "dc93f22caadcde35daf5cc2cd65d2738c87e31ca",
+      "whiteSpace": "SHOW"
+    }
+  ],
+  "truncated": "true",
+  "contextLines": "10",
+  "fromHash": "a0f224fd7bd5f28ea5a752d41b9c9f6372fc6d9e",
+  "toHash": "dc93f22caadcde35daf5cc2cd65d2738c87e31ca",
+  "whiteSpace": "SHOW"
+}

--- a/vcsclient/testdata/github/compare_commits.json
+++ b/vcsclient/testdata/github/compare_commits.json
@@ -1,0 +1,694 @@
+{
+  "url": "https://api.github.com/repos/jfrog/froggit-go/compare/ce1965514d711e17045b849e11105d9c095ee935...d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+  "html_url": "https://github.com/jfrog/froggit-go/compare/ce1965514d711e17045b849e11105d9c095ee935...d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+  "permalink_url": "https://github.com/jfrog/froggit-go/compare/jfrog:ce19655...jfrog:d41c3fc",
+  "diff_url": "https://github.com/jfrog/froggit-go/compare/ce1965514d711e17045b849e11105d9c095ee935...d41c3fcff4ea7d18e753977f5d63d5003becaa2f.diff",
+  "patch_url": "https://github.com/jfrog/froggit-go/compare/ce1965514d711e17045b849e11105d9c095ee935...d41c3fcff4ea7d18e753977f5d63d5003becaa2f.patch",
+  "base_commit": {
+    "sha": "ce1965514d711e17045b849e11105d9c095ee935",
+    "node_id": "C_kwDOF_Bo3doAKGNlMTk2NTUxNGQ3MTFlMTcwNDViODQ5ZTExMTA1ZDljMDk1ZWU5MzU",
+    "commit": {
+      "author": {
+        "name": "Omer Zidkoni",
+        "email": "50792403+omerzi@users.noreply.github.com",
+        "date": "2023-01-10T11:25:46Z"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "date": "2023-01-10T11:25:46Z"
+      },
+      "message": "Need to check 404 status code before error (#60)",
+      "tree": {
+        "sha": "13b0df20c75390cc2537caab7c26c1bb004c3f72",
+        "url": "https://api.github.com/repos/jfrog/froggit-go/git/trees/13b0df20c75390cc2537caab7c26c1bb004c3f72"
+      },
+      "url": "https://api.github.com/repos/jfrog/froggit-go/git/commits/ce1965514d711e17045b849e11105d9c095ee935",
+      "comment_count": 0,
+      "verification": {
+        "verified": true,
+        "reason": "valid",
+        "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJjvUs6CRBK7hj4Ov3rIwAAiwwIABFHcsTPoVa5ghSZ/bq89Zqu\nnqvE6xZfLAKxyYX/sZ6d4FUHoit8J6+pPOX4jY2Mux8JUUjuROv+a/jKCPiI5JBB\nSkqS7ra6+b1+Fb17aqO/HUpj2GKx9vjFqpcQ+hl1A5xvmZhBJLwR3Q5vrgNGvtfT\n3aYq60HccTgVJqWdc6du2MOm2xehNgAPozta+jQ/YZ6grL1IdR5KDLnUSY0f10W+\nNI4vlyj5Z6ZVHpxeUOxlYFVgB9cEoC09fgr79ROyGsHR92SedyFXUMYy2lS7jG8A\nU6TxW0ReqyHY8XPJUNVO2+McZMt4U85JNocn4uk3BL+RMcEOTCsb+PTmzqvTfUY=\n=ZqXv\n-----END PGP SIGNATURE-----\n",
+        "payload": "tree 13b0df20c75390cc2537caab7c26c1bb004c3f72\nparent c3649965053dc53c26814487e381a1eb4f8832b8\nauthor Omer Zidkoni <50792403+omerzi@users.noreply.github.com> 1673349946 +0200\ncommitter GitHub <noreply@github.com> 1673349946 +0200\n\nNeed to check 404 status code before error (#60)\n\n"
+      }
+    },
+    "url": "https://api.github.com/repos/jfrog/froggit-go/commits/ce1965514d711e17045b849e11105d9c095ee935",
+    "html_url": "https://github.com/jfrog/froggit-go/commit/ce1965514d711e17045b849e11105d9c095ee935",
+    "comments_url": "https://api.github.com/repos/jfrog/froggit-go/commits/ce1965514d711e17045b849e11105d9c095ee935/comments",
+    "author": {
+      "login": "omerzi",
+      "id": 50792403,
+      "node_id": "MDQ6VXNlcjUwNzkyNDAz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50792403?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/omerzi",
+      "html_url": "https://github.com/omerzi",
+      "followers_url": "https://api.github.com/users/omerzi/followers",
+      "following_url": "https://api.github.com/users/omerzi/following{/other_user}",
+      "gists_url": "https://api.github.com/users/omerzi/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/omerzi/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/omerzi/subscriptions",
+      "organizations_url": "https://api.github.com/users/omerzi/orgs",
+      "repos_url": "https://api.github.com/users/omerzi/repos",
+      "events_url": "https://api.github.com/users/omerzi/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/omerzi/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "web-flow",
+      "id": 19864447,
+      "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/web-flow",
+      "html_url": "https://github.com/web-flow",
+      "followers_url": "https://api.github.com/users/web-flow/followers",
+      "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+      "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+      "organizations_url": "https://api.github.com/users/web-flow/orgs",
+      "repos_url": "https://api.github.com/users/web-flow/repos",
+      "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/web-flow/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "c3649965053dc53c26814487e381a1eb4f8832b8",
+        "url": "https://api.github.com/repos/jfrog/froggit-go/commits/c3649965053dc53c26814487e381a1eb4f8832b8",
+        "html_url": "https://github.com/jfrog/froggit-go/commit/c3649965053dc53c26814487e381a1eb4f8832b8"
+      }
+    ]
+  },
+  "merge_base_commit": {
+    "sha": "ce1965514d711e17045b849e11105d9c095ee935",
+    "node_id": "C_kwDOF_Bo3doAKGNlMTk2NTUxNGQ3MTFlMTcwNDViODQ5ZTExMTA1ZDljMDk1ZWU5MzU",
+    "commit": {
+      "author": {
+        "name": "Omer Zidkoni",
+        "email": "50792403+omerzi@users.noreply.github.com",
+        "date": "2023-01-10T11:25:46Z"
+      },
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "date": "2023-01-10T11:25:46Z"
+      },
+      "message": "Need to check 404 status code before error (#60)",
+      "tree": {
+        "sha": "13b0df20c75390cc2537caab7c26c1bb004c3f72",
+        "url": "https://api.github.com/repos/jfrog/froggit-go/git/trees/13b0df20c75390cc2537caab7c26c1bb004c3f72"
+      },
+      "url": "https://api.github.com/repos/jfrog/froggit-go/git/commits/ce1965514d711e17045b849e11105d9c095ee935",
+      "comment_count": 0,
+      "verification": {
+        "verified": true,
+        "reason": "valid",
+        "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJjvUs6CRBK7hj4Ov3rIwAAiwwIABFHcsTPoVa5ghSZ/bq89Zqu\nnqvE6xZfLAKxyYX/sZ6d4FUHoit8J6+pPOX4jY2Mux8JUUjuROv+a/jKCPiI5JBB\nSkqS7ra6+b1+Fb17aqO/HUpj2GKx9vjFqpcQ+hl1A5xvmZhBJLwR3Q5vrgNGvtfT\n3aYq60HccTgVJqWdc6du2MOm2xehNgAPozta+jQ/YZ6grL1IdR5KDLnUSY0f10W+\nNI4vlyj5Z6ZVHpxeUOxlYFVgB9cEoC09fgr79ROyGsHR92SedyFXUMYy2lS7jG8A\nU6TxW0ReqyHY8XPJUNVO2+McZMt4U85JNocn4uk3BL+RMcEOTCsb+PTmzqvTfUY=\n=ZqXv\n-----END PGP SIGNATURE-----\n",
+        "payload": "tree 13b0df20c75390cc2537caab7c26c1bb004c3f72\nparent c3649965053dc53c26814487e381a1eb4f8832b8\nauthor Omer Zidkoni <50792403+omerzi@users.noreply.github.com> 1673349946 +0200\ncommitter GitHub <noreply@github.com> 1673349946 +0200\n\nNeed to check 404 status code before error (#60)\n\n"
+      }
+    },
+    "url": "https://api.github.com/repos/jfrog/froggit-go/commits/ce1965514d711e17045b849e11105d9c095ee935",
+    "html_url": "https://github.com/jfrog/froggit-go/commit/ce1965514d711e17045b849e11105d9c095ee935",
+    "comments_url": "https://api.github.com/repos/jfrog/froggit-go/commits/ce1965514d711e17045b849e11105d9c095ee935/comments",
+    "author": {
+      "login": "omerzi",
+      "id": 50792403,
+      "node_id": "MDQ6VXNlcjUwNzkyNDAz",
+      "avatar_url": "https://avatars.githubusercontent.com/u/50792403?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/omerzi",
+      "html_url": "https://github.com/omerzi",
+      "followers_url": "https://api.github.com/users/omerzi/followers",
+      "following_url": "https://api.github.com/users/omerzi/following{/other_user}",
+      "gists_url": "https://api.github.com/users/omerzi/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/omerzi/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/omerzi/subscriptions",
+      "organizations_url": "https://api.github.com/users/omerzi/orgs",
+      "repos_url": "https://api.github.com/users/omerzi/repos",
+      "events_url": "https://api.github.com/users/omerzi/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/omerzi/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "committer": {
+      "login": "web-flow",
+      "id": 19864447,
+      "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+      "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/web-flow",
+      "html_url": "https://github.com/web-flow",
+      "followers_url": "https://api.github.com/users/web-flow/followers",
+      "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+      "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+      "organizations_url": "https://api.github.com/users/web-flow/orgs",
+      "repos_url": "https://api.github.com/users/web-flow/repos",
+      "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/web-flow/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "parents": [
+      {
+        "sha": "c3649965053dc53c26814487e381a1eb4f8832b8",
+        "url": "https://api.github.com/repos/jfrog/froggit-go/commits/c3649965053dc53c26814487e381a1eb4f8832b8",
+        "html_url": "https://github.com/jfrog/froggit-go/commit/c3649965053dc53c26814487e381a1eb4f8832b8"
+      }
+    ]
+  },
+  "status": "ahead",
+  "ahead_by": 4,
+  "behind_by": 0,
+  "total_commits": 4,
+  "commits": [
+    {
+      "sha": "d91178a2c1e88d25807cd9cefbaa856fc2562081",
+      "node_id": "C_kwDOF_Bo3doAKGQ5MTE3OGEyYzFlODhkMjU4MDdjZDljZWZiYWE4NTZmYzI1NjIwODE",
+      "commit": {
+        "author": {
+          "name": "Omer Zidkoni",
+          "email": "50792403+omerzi@users.noreply.github.com",
+          "date": "2023-01-24T13:27:58Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2023-01-24T13:27:58Z"
+        },
+        "message": "Added DownloadFileFromRepository to Bitbucket Server (#61)",
+        "tree": {
+          "sha": "2d7d8f7556c6a4b2da212a1b6a856edd823b46d4",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/git/trees/2d7d8f7556c6a4b2da212a1b6a856edd823b46d4"
+        },
+        "url": "https://api.github.com/repos/jfrog/froggit-go/git/commits/d91178a2c1e88d25807cd9cefbaa856fc2562081",
+        "comment_count": 0,
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJjz9zeCRBK7hj4Ov3rIwAAPeEIABRT8/uWCVBZb5Xnf79RGklU\nr5SNgHFywVZQPgMbKNBMJpry3nMHCv8R/WbonYK/cO/znixEr1ZzZhGP9U3lNdRV\nmDuPEh6hRkLpAApfl5s1d1HbN7BhFbQClkDM0v8uRDU8gm3ZjQVUh9mFpsmDJqA2\nfbq9Ogp8DBaplukWoVzlcHMhlHUucMc+7Vy9Eh3ooJEQO3jJckRy8iphJQh4Ir/L\ni2U3u4hS3G9DzcWrVKgvybQSTaqtbIfC+G8iF4eoACioa3Fvgdv+fikCV9BRLKwR\nG4uDD6NEpb+9t+S/zyYBvQmMioei+t1UxRrGH5tE3dCtK0LM0s96Ymn1VbXNOKA=\n=Kuie\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree 2d7d8f7556c6a4b2da212a1b6a856edd823b46d4\nparent ce1965514d711e17045b849e11105d9c095ee935\nauthor Omer Zidkoni <50792403+omerzi@users.noreply.github.com> 1674566878 +0200\ncommitter GitHub <noreply@github.com> 1674566878 +0200\n\nAdded DownloadFileFromRepository to Bitbucket Server (#61)\n\n"
+        }
+      },
+      "url": "https://api.github.com/repos/jfrog/froggit-go/commits/d91178a2c1e88d25807cd9cefbaa856fc2562081",
+      "html_url": "https://github.com/jfrog/froggit-go/commit/d91178a2c1e88d25807cd9cefbaa856fc2562081",
+      "comments_url": "https://api.github.com/repos/jfrog/froggit-go/commits/d91178a2c1e88d25807cd9cefbaa856fc2562081/comments",
+      "author": {
+        "login": "omerzi",
+        "id": 50792403,
+        "node_id": "MDQ6VXNlcjUwNzkyNDAz",
+        "avatar_url": "https://avatars.githubusercontent.com/u/50792403?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/omerzi",
+        "html_url": "https://github.com/omerzi",
+        "followers_url": "https://api.github.com/users/omerzi/followers",
+        "following_url": "https://api.github.com/users/omerzi/following{/other_user}",
+        "gists_url": "https://api.github.com/users/omerzi/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/omerzi/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/omerzi/subscriptions",
+        "organizations_url": "https://api.github.com/users/omerzi/orgs",
+        "repos_url": "https://api.github.com/users/omerzi/repos",
+        "events_url": "https://api.github.com/users/omerzi/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/omerzi/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "web-flow",
+        "id": 19864447,
+        "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/web-flow",
+        "html_url": "https://github.com/web-flow",
+        "followers_url": "https://api.github.com/users/web-flow/followers",
+        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+        "organizations_url": "https://api.github.com/users/web-flow/orgs",
+        "repos_url": "https://api.github.com/users/web-flow/repos",
+        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/web-flow/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "sha": "ce1965514d711e17045b849e11105d9c095ee935",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/commits/ce1965514d711e17045b849e11105d9c095ee935",
+          "html_url": "https://github.com/jfrog/froggit-go/commit/ce1965514d711e17045b849e11105d9c095ee935"
+        }
+      ]
+    },
+    {
+      "sha": "fde40c049ee36634a0f68976be011e6d1bd8d970",
+      "node_id": "C_kwDOF_Bo3doAKGZkZTQwYzA0OWVlMzY2MzRhMGY2ODk3NmJlMDExZTZkMWJkOGQ5NzA",
+      "commit": {
+        "author": {
+          "name": "Yahav Itzhak",
+          "email": "yahavi@users.noreply.github.com",
+          "date": "2023-01-26T12:16:19Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2023-01-26T12:16:19Z"
+        },
+        "message": "Add repository visibility to the repository info (#63)",
+        "tree": {
+          "sha": "1117761f49d90778e1d0207aad86560a744a4044",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/git/trees/1117761f49d90778e1d0207aad86560a744a4044"
+        },
+        "url": "https://api.github.com/repos/jfrog/froggit-go/git/commits/fde40c049ee36634a0f68976be011e6d1bd8d970",
+        "comment_count": 0,
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJj0m8TCRBK7hj4Ov3rIwAAWGMIAJuSqp2gJCM0WY1qmdsVS8VS\nyjZmWbJzLIGQkrjurIXRVDNXTRwU1Zsw+eEQSKRvF0YNSOw0kp/Uq/NGyqBBtcim\n0qXrNo48KLD4M7RUeRDKOfbq5k792yqGb06JJNmR+RcrHzEidgRhJPSCOF1CsMDI\ngc/jQF1Kxsv75IKeQz+K4FztVpO5QpnWNRBb8LmkdIjADm/ahr+IShIZc+qtI4PO\n+Lz0UsBwedRR21JrPQuU1CyLam6cydgmzm3Udu5W5O7YH39JrNeHlFrxrQrdjhTk\n4PoQEW5hpffA2cy2QYSI8d+c1v+m9QB9KJDaede+CjJSuMEBEogxKSsYtYejRNs=\n=MOKX\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree 1117761f49d90778e1d0207aad86560a744a4044\nparent d91178a2c1e88d25807cd9cefbaa856fc2562081\nauthor Yahav Itzhak <yahavi@users.noreply.github.com> 1674735379 +0200\ncommitter GitHub <noreply@github.com> 1674735379 +0200\n\nAdd repository visibility to the repository info (#63)\n\n"
+        }
+      },
+      "url": "https://api.github.com/repos/jfrog/froggit-go/commits/fde40c049ee36634a0f68976be011e6d1bd8d970",
+      "html_url": "https://github.com/jfrog/froggit-go/commit/fde40c049ee36634a0f68976be011e6d1bd8d970",
+      "comments_url": "https://api.github.com/repos/jfrog/froggit-go/commits/fde40c049ee36634a0f68976be011e6d1bd8d970/comments",
+      "author": {
+        "login": "yahavi",
+        "id": 11367982,
+        "node_id": "MDQ6VXNlcjExMzY3OTgy",
+        "avatar_url": "https://avatars.githubusercontent.com/u/11367982?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/yahavi",
+        "html_url": "https://github.com/yahavi",
+        "followers_url": "https://api.github.com/users/yahavi/followers",
+        "following_url": "https://api.github.com/users/yahavi/following{/other_user}",
+        "gists_url": "https://api.github.com/users/yahavi/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/yahavi/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/yahavi/subscriptions",
+        "organizations_url": "https://api.github.com/users/yahavi/orgs",
+        "repos_url": "https://api.github.com/users/yahavi/repos",
+        "events_url": "https://api.github.com/users/yahavi/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/yahavi/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "web-flow",
+        "id": 19864447,
+        "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/web-flow",
+        "html_url": "https://github.com/web-flow",
+        "followers_url": "https://api.github.com/users/web-flow/followers",
+        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+        "organizations_url": "https://api.github.com/users/web-flow/orgs",
+        "repos_url": "https://api.github.com/users/web-flow/repos",
+        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/web-flow/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "sha": "d91178a2c1e88d25807cd9cefbaa856fc2562081",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/commits/d91178a2c1e88d25807cd9cefbaa856fc2562081",
+          "html_url": "https://github.com/jfrog/froggit-go/commit/d91178a2c1e88d25807cd9cefbaa856fc2562081"
+        }
+      ]
+    },
+    {
+      "sha": "8e82000949b516896bf11754dc5637872eac8e75",
+      "node_id": "C_kwDOF_Bo3doAKDhlODIwMDA5NDliNTE2ODk2YmYxMTc1NGRjNTYzNzg3MmVhYzhlNzU",
+      "commit": {
+        "author": {
+          "name": "Omer Zidkoni",
+          "email": "50792403+omerzi@users.noreply.github.com",
+          "date": "2023-01-26T14:26:35Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2023-01-26T14:26:35Z"
+        },
+        "message": "Fix Azure Devops Server remote details (#65)",
+        "tree": {
+          "sha": "3ada68f2e9cb8e61fbe45d12d674286d4e93bda2",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/git/trees/3ada68f2e9cb8e61fbe45d12d674286d4e93bda2"
+        },
+        "url": "https://api.github.com/repos/jfrog/froggit-go/git/commits/8e82000949b516896bf11754dc5637872eac8e75",
+        "comment_count": 0,
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJj0o2bCRBK7hj4Ov3rIwAAE6oIADwgD64JZbWnsC0GnZmM5Gwy\n+BtKsHMgyMCUNBGVV9udAfbFG6QRv2hXu4xaAjOIoQqlLblJyz0XXLgAynxj/sVy\nA5zdI5l6FddZYUIBkVhQIIC6lbPT+cVVcY2HVTnvoOz8C09uAp1bsS4ka8i13bFD\nz+8IgQ+lRaneb3gt3zAwwybsz5ZQZT1QsEORLUO4x3o6pgNszjtLybTkyJYfaNG9\nhpmpqDzQ4DPfU6eo0HnLc1tKhhtMSagIDRkN3hYAk67Ju/vWpX0VMz593604BpU3\nnz7oznvGgfchnNMWma7/IwBbSK6kGmCxGuluCnRhdoxZaBJtUAa9s9Yytju85u8=\n=kv8p\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree 3ada68f2e9cb8e61fbe45d12d674286d4e93bda2\nparent fde40c049ee36634a0f68976be011e6d1bd8d970\nauthor Omer Zidkoni <50792403+omerzi@users.noreply.github.com> 1674743195 +0200\ncommitter GitHub <noreply@github.com> 1674743195 +0200\n\nFix Azure Devops Server remote details (#65)\n\n"
+        }
+      },
+      "url": "https://api.github.com/repos/jfrog/froggit-go/commits/8e82000949b516896bf11754dc5637872eac8e75",
+      "html_url": "https://github.com/jfrog/froggit-go/commit/8e82000949b516896bf11754dc5637872eac8e75",
+      "comments_url": "https://api.github.com/repos/jfrog/froggit-go/commits/8e82000949b516896bf11754dc5637872eac8e75/comments",
+      "author": {
+        "login": "omerzi",
+        "id": 50792403,
+        "node_id": "MDQ6VXNlcjUwNzkyNDAz",
+        "avatar_url": "https://avatars.githubusercontent.com/u/50792403?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/omerzi",
+        "html_url": "https://github.com/omerzi",
+        "followers_url": "https://api.github.com/users/omerzi/followers",
+        "following_url": "https://api.github.com/users/omerzi/following{/other_user}",
+        "gists_url": "https://api.github.com/users/omerzi/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/omerzi/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/omerzi/subscriptions",
+        "organizations_url": "https://api.github.com/users/omerzi/orgs",
+        "repos_url": "https://api.github.com/users/omerzi/repos",
+        "events_url": "https://api.github.com/users/omerzi/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/omerzi/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "web-flow",
+        "id": 19864447,
+        "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/web-flow",
+        "html_url": "https://github.com/web-flow",
+        "followers_url": "https://api.github.com/users/web-flow/followers",
+        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+        "organizations_url": "https://api.github.com/users/web-flow/orgs",
+        "repos_url": "https://api.github.com/users/web-flow/repos",
+        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/web-flow/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "sha": "fde40c049ee36634a0f68976be011e6d1bd8d970",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/commits/fde40c049ee36634a0f68976be011e6d1bd8d970",
+          "html_url": "https://github.com/jfrog/froggit-go/commit/fde40c049ee36634a0f68976be011e6d1bd8d970"
+        }
+      ]
+    },
+    {
+      "sha": "d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "node_id": "C_kwDOF_Bo3doAKGQ0MWMzZmNmZjRlYTdkMThlNzUzOTc3ZjVkNjNkNTAwM2JlY2FhMmY",
+      "commit": {
+        "author": {
+          "name": "Yahav Itzhak",
+          "email": "yahavi@users.noreply.github.com",
+          "date": "2023-01-26T14:35:31Z"
+        },
+        "committer": {
+          "name": "GitHub",
+          "email": "noreply@github.com",
+          "date": "2023-01-26T14:35:31Z"
+        },
+        "message": "New Get Repository Environment Info API (#64)",
+        "tree": {
+          "sha": "e6b4d9994d01d0f082851e9acaa253fbb7115d51",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/git/trees/e6b4d9994d01d0f082851e9acaa253fbb7115d51"
+        },
+        "url": "https://api.github.com/repos/jfrog/froggit-go/git/commits/d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+        "comment_count": 0,
+        "verification": {
+          "verified": true,
+          "reason": "valid",
+          "signature": "-----BEGIN PGP SIGNATURE-----\n\nwsBcBAABCAAQBQJj0o+zCRBK7hj4Ov3rIwAAA4YIACFTuvoQBXEs1pzxsi2mz1Ut\nwIr8jsFFO3BU+vUGsGfS+2dCrz8WjLYfbzqnj0sr/VFIdkVTbn8FkzKmcW/grakr\nyCFdB8hThZaW0hLtg7mtmxkNqXiQKPWHVNuN8S7UEy0JmfvNhe92Ksw/+p6Sgijl\nluUEdTRy1GPhRXMfl1yU6/Gha0jNevncw3XpNze0o58Vsbbm17RpEk+sLVAkxgQF\nZ7hCUb3FQTh7C4kX1h7TV8dbuDebuR3Tb5ItPqZJ6rQlXcNIYugFfOMI1fR1rZhQ\nTU9Gi4R+CToA4jHMuV5zO1mT3A0/Cmk+lm4pEXqHuCVAeV/8bXakI0moGvYw7bE=\n=6QBu\n-----END PGP SIGNATURE-----\n",
+          "payload": "tree e6b4d9994d01d0f082851e9acaa253fbb7115d51\nparent 8e82000949b516896bf11754dc5637872eac8e75\nauthor Yahav Itzhak <yahavi@users.noreply.github.com> 1674743731 +0200\ncommitter GitHub <noreply@github.com> 1674743731 +0200\n\nNew Get Repository Environment Info API (#64)\n\n"
+        }
+      },
+      "url": "https://api.github.com/repos/jfrog/froggit-go/commits/d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "html_url": "https://github.com/jfrog/froggit-go/commit/d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "comments_url": "https://api.github.com/repos/jfrog/froggit-go/commits/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/comments",
+      "author": {
+        "login": "yahavi",
+        "id": 11367982,
+        "node_id": "MDQ6VXNlcjExMzY3OTgy",
+        "avatar_url": "https://avatars.githubusercontent.com/u/11367982?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/yahavi",
+        "html_url": "https://github.com/yahavi",
+        "followers_url": "https://api.github.com/users/yahavi/followers",
+        "following_url": "https://api.github.com/users/yahavi/following{/other_user}",
+        "gists_url": "https://api.github.com/users/yahavi/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/yahavi/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/yahavi/subscriptions",
+        "organizations_url": "https://api.github.com/users/yahavi/orgs",
+        "repos_url": "https://api.github.com/users/yahavi/repos",
+        "events_url": "https://api.github.com/users/yahavi/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/yahavi/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "committer": {
+        "login": "web-flow",
+        "id": 19864447,
+        "node_id": "MDQ6VXNlcjE5ODY0NDQ3",
+        "avatar_url": "https://avatars.githubusercontent.com/u/19864447?v=4",
+        "gravatar_id": "",
+        "url": "https://api.github.com/users/web-flow",
+        "html_url": "https://github.com/web-flow",
+        "followers_url": "https://api.github.com/users/web-flow/followers",
+        "following_url": "https://api.github.com/users/web-flow/following{/other_user}",
+        "gists_url": "https://api.github.com/users/web-flow/gists{/gist_id}",
+        "starred_url": "https://api.github.com/users/web-flow/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/web-flow/subscriptions",
+        "organizations_url": "https://api.github.com/users/web-flow/orgs",
+        "repos_url": "https://api.github.com/users/web-flow/repos",
+        "events_url": "https://api.github.com/users/web-flow/events{/privacy}",
+        "received_events_url": "https://api.github.com/users/web-flow/received_events",
+        "type": "User",
+        "site_admin": false
+      },
+      "parents": [
+        {
+          "sha": "8e82000949b516896bf11754dc5637872eac8e75",
+          "url": "https://api.github.com/repos/jfrog/froggit-go/commits/8e82000949b516896bf11754dc5637872eac8e75",
+          "html_url": "https://github.com/jfrog/froggit-go/commit/8e82000949b516896bf11754dc5637872eac8e75"
+        }
+      ]
+    }
+  ],
+  "files": [
+    {
+      "sha": "7cc8f8b04af7b067a0dc5342ecc965389b30648a",
+      "filename": "README.md",
+      "status": "modified",
+      "additions": 25,
+      "deletions": 6,
+      "changes": 31,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/README.md",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/README.md",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/README.md?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -3,6 +3,7 @@\n # Froggit-Go\n \n [![Frogbot](images/header.png)](#readme)\n+\n </div>\n \n Froggit-Go is a Go library, allowing to perform actions on VCS providers.\n@@ -41,6 +42,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc\n       - [Get Commit By SHA](#get-commit-by-sha)\n       - [Add Public SSH Key](#add-public-ssh-key)\n       - [Get Repository Info](#get-repository-info)\n+      - [Get Repository Environment Info](#get-repository-environment-info)\n       - [Create a label](#create-a-label)\n       - [Get a label](#get-a-label)\n       - [List Pull Request Labels](#list-pull-request-labels)\n@@ -66,7 +68,7 @@ apiEndpoint := \"https://github.example.com\"\n token := \"secret-github-token\"\n // Logger\n // [Optional]\n-// Supported logger is a logger that implements the Log interface. \n+// Supported logger is a logger that implements the Log interface.\n // More information - https://github.com/jfrog/froggit-go/blob/master/vcsclient/logger.go\n logger := log.Default()\n \n@@ -86,7 +88,7 @@ apiEndpoint := \"https://gitlab.example.com\"\n token := \"secret-gitlab-token\"\n // Logger\n // [Optional]\n-// Supported logger is a logger that implements the Log interface. \n+// Supported logger is a logger that implements the Log interface.\n // More information - https://github.com/jfrog/froggit-go/blob/master/vcsclient/logger.go\n logger := logger\n \n@@ -106,7 +108,7 @@ apiEndpoint := \"https://git.acme.com/rest\"\n token := \"secret-bitbucket-token\"\n // Logger\n // [Optional]\n-// Supported logger is a logger that implements the Log interface. \n+// Supported logger is a logger that implements the Log interface.\n // More information - https://github.com/jfrog/froggit-go/blob/master/vcsclient/logger.go\n logger := log.Default()\n \n@@ -128,7 +130,7 @@ username := \"bitbucket-user\"\n token := \"secret-bitbucket-token\"\n // Logger\n // [Optional]\n-// Supported logger is a logger that implements the Log interface. \n+// Supported logger is a logger that implements the Log interface.\n // More information - https://github.com/jfrog/froggit-go/blob/master/vcsclient/logger.go\n logger := log.Default()\n \n@@ -148,7 +150,7 @@ apiEndpoint := \"https://dev.azure.com/<organization>\"\n token := \"secret-azure-devops-token\"\n // Logger\n // [Optional]\n-// Supported logger is a logger that implements the Log interface. \n+// Supported logger is a logger that implements the Log interface.\n // More information - https://github.com/jfrog/froggit-go/blob/master/vcsclient/logger.go\n logger := log.Default()\n // Project name\n@@ -420,6 +422,24 @@ repository := \"jfrog-cli\"\n repoInfo, err := client.GetRepositoryInfo(ctx, owner, repository)\n ```\n \n+#### Get Repository Environment Info\n+\n+Notice - Get Repository Environment Info is currently supported on GitHub only.\n+\n+```go\n+// Go context\n+ctx := context.Background()\n+// Organization or username\n+owner := \"jfrog\"\n+// VCS repository\n+repository := \"jfrog-cli\"\n+// Environment name\n+name := \"frogbot\"\n+\n+// Get information about repository environment\n+repoEnvInfo, err := client.GetRepositoryEnvironmentInfo(ctx, owner, repository, name)\n+```\n+\n #### Create a label\n \n Notice - Labels are not supported in Bitbucket\n@@ -552,4 +572,3 @@ provider := vcsutils.GitHub\n \n webhookInfo, err := webhookparser.ParseIncomingWebhook(provider, token, request)\n ```\n-"
+    },
+    {
+      "sha": "01595a2e4b453632deeb18c9b5c7fbf7c286c2f7",
+      "filename": "vcsclient/azurerepos.go",
+      "status": "modified",
+      "additions": 6,
+      "deletions": 1,
+      "changes": 7,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fazurerepos.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fazurerepos.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fazurerepos.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -115,7 +115,7 @@ func (client *AzureReposClient) DownloadRepository(ctx context.Context, owner, r\n \tclient.logger.Info(\"extracted repository successfully\")\n \t// Generate .git folder with remote details\n \treturn vcsutils.CreateDotGitFolderWithRemote(localPath, \"origin\",\n-\t\tfmt.Sprintf(\"https://%s@dev.azure.com/%s/%s/_git/%s\", owner, owner, client.vcsInfo.Project, repository))\n+\t\tfmt.Sprintf(\"https://%s@%s/%s/_git/%s\", owner, strings.TrimPrefix(client.connectionDetails.BaseUrl, \"https://\"), client.vcsInfo.Project, repository))\n }\n \n func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, repository string, branch string) (res *http.Response, err error) {\n@@ -360,3 +360,8 @@ func (client *AzureReposClient) SetCommitStatus(ctx context.Context, commitStatu\n func (client *AzureReposClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {\n \treturn nil, 0, getUnsupportedInAzureError(\"download file from repo\")\n }\n+\n+// GetRepositoryEnvironmentInfo on GitLab\n+func (client *AzureReposClient) GetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error) {\n+\treturn RepositoryEnvironmentInfo{}, getUnsupportedInAzureError(\"get repository environment info\")\n+}"
+    },
+    {
+      "sha": "423998e750c7fd95b69332db6f8a90a640beb128",
+      "filename": "vcsclient/azurerepos_test.go",
+      "status": "modified",
+      "additions": 8,
+      "deletions": 0,
+      "changes": 8,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fazurerepos_test.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fazurerepos_test.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fazurerepos_test.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -365,6 +365,14 @@ func TestAzureReposClient_GetLabel(t *testing.T) {\n \tassert.Error(t, err)\n }\n \n+func TestAzureReposClient_GetRepositoryEnvironmentInfo(t *testing.T) {\n+\tctx := context.Background()\n+\tclient, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, \"\", \"unsupportedTest\", createAzureReposHandler)\n+\tdefer cleanUp()\n+\t_, err := client.GetRepositoryEnvironmentInfo(ctx, owner, repo1, envName)\n+\tassert.Error(t, err)\n+}\n+\n func TestGetUnsupportedInAzureError(t *testing.T) {\n \tfunctionName := \"foo\"\n \tassert.Error(t, getUnsupportedInAzureError(functionName))"
+    },
+    {
+      "sha": "f013cbf26044361ff618fd4dbe56e9a691c40fd2",
+      "filename": "vcsclient/bitbucketcloud.go",
+      "status": "modified",
+      "additions": 13,
+      "deletions": 1,
+      "changes": 14,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketcloud.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketcloud.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fbitbucketcloud.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -405,7 +405,7 @@ func (client *BitbucketCloudClient) GetRepositoryInfo(ctx context.Context, owner\n \t\t\tinfo.SSH = link.HRef\n \t\t}\n \t}\n-\treturn RepositoryInfo{CloneInfo: info}, nil\n+\treturn RepositoryInfo{RepositoryVisibility: getBitbucketCloudRepositoryVisibility(repo), CloneInfo: info}, nil\n }\n \n // GetCommitBySha on Bitbucket cloud\n@@ -466,6 +466,11 @@ func (client *BitbucketCloudClient) DownloadFileFromRepo(ctx context.Context, ow\n \treturn nil, 0, errBitbucketDownloadFileFromRepoNotSupported\n }\n \n+// GetRepositoryEnvironmentInfo on Bitbucket cloud\n+func (client *BitbucketCloudClient) GetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error) {\n+\treturn RepositoryEnvironmentInfo{}, errBitbucketGetRepoEnvironmentInfoNotSupported\n+}\n+\n func extractCommitFromResponse(commits interface{}) (*commitResponse, error) {\n \tvar res commitResponse\n \terr := extractStructFromResponse(commits, &res)\n@@ -659,3 +664,10 @@ func mapBitbucketCloudPullRequestToPullRequestInfo(parsedPullRequests *pullReque\n \t}\n \treturn pullRequests\n }\n+\n+func getBitbucketCloudRepositoryVisibility(repo *bitbucket.Repository) RepositoryVisibility {\n+\tif repo.Is_private {\n+\t\treturn Private\n+\t}\n+\treturn Public\n+}"
+    },
+    {
+      "sha": "63e8828376cb0ccdacd473237ae12dc06c5c11be",
+      "filename": "vcsclient/bitbucketcloud_test.go",
+      "status": "modified",
+      "additions": 15,
+      "deletions": 0,
+      "changes": 15,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketcloud_test.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketcloud_test.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fbitbucketcloud_test.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -375,6 +375,7 @@ func TestBitbucketCloud_GetRepositoryInfo(t *testing.T) {\n \trequire.NoError(t, err)\n \trequire.Equal(t,\n \t\tRepositoryInfo{\n+\t\t\tRepositoryVisibility: Public,\n \t\t\tCloneInfo: CloneInfo{\n \t\t\t\tHTTP: \"https://bitbucket.org/jfrog/jfrog-setup-cli.git\",\n \t\t\t\tSSH:  \"git@bitbucket.org:jfrog/jfrog-setup-cli.git\",\n@@ -429,6 +430,20 @@ func TestBitbucketCloud_UnlabelPullRequest(t *testing.T) {\n \tassert.ErrorIs(t, err, errLabelsNotSupported)\n }\n \n+func TestBitbucketCloud_GetRepositoryEnvironmentInfo(t *testing.T) {\n+\tctx := context.Background()\n+\tclient, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()\n+\tassert.NoError(t, err)\n+\n+\t_, err = client.GetRepositoryEnvironmentInfo(ctx, owner, repo1, envName)\n+\tassert.ErrorIs(t, err, errBitbucketGetRepoEnvironmentInfoNotSupported)\n+}\n+\n+func TestBitbucketCloud_getRepositoryVisibility(t *testing.T) {\n+\tassert.Equal(t, Private, getBitbucketCloudRepositoryVisibility(&bitbucket.Repository{Is_private: true}))\n+\tassert.Equal(t, Public, getBitbucketCloudRepositoryVisibility(&bitbucket.Repository{Is_private: false}))\n+}\n+\n func createBitbucketCloudHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {\n \treturn func(w http.ResponseWriter, r *http.Request) {\n \t\tw.WriteHeader(expectedStatusCode)"
+    },
+    {
+      "sha": "5ba8718a766b93405e57c8eff70d2c8efd5c727e",
+      "filename": "vcsclient/bitbucketcommon.go",
+      "status": "modified",
+      "additions": 1,
+      "deletions": 0,
+      "changes": 1,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketcommon.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketcommon.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fbitbucketcommon.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -8,6 +8,7 @@ var errLabelsNotSupported = errors.New(\"labels are not supported on Bitbucket\")\n var errBitbucketCodeScanningNotSupported = errors.New(\"code scanning is not supported on Bitbucket\")\n \n var errBitbucketDownloadFileFromRepoNotSupported = errors.New(\"download file from repo is currently not supported on Bitbucket\")\n+var errBitbucketGetRepoEnvironmentInfoNotSupported = errors.New(\"get repository environment info is currently not supported on Bitbucket\")\n \n func getBitbucketCommitState(commitState CommitStatus) string {\n \tswitch commitState {"
+    },
+    {
+      "sha": "feeb83f23deb5286bf05857a4530064ebf3cb17c",
+      "filename": "vcsclient/bitbucketserver.go",
+      "status": "modified",
+      "additions": 23,
+      "deletions": 2,
+      "changes": 25,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketserver.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketserver.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fbitbucketserver.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -455,6 +455,7 @@ func (client *BitbucketServerClient) GetRepositoryInfo(ctx context.Context, owne\n \t\t\t\tHRef string `mapstructure:\"href\"`\n \t\t\t} `mapstructure:\"clone\"`\n \t\t} `mapstructure:\"links\"`\n+\t\tPublic bool `mapstructure:\"public\"`\n \t}{}\n \n \tif err := mapstructure.Decode(repo.Values, &holder); err != nil {\n@@ -471,7 +472,7 @@ func (client *BitbucketServerClient) GetRepositoryInfo(ctx context.Context, owne\n \t\t}\n \t}\n \n-\treturn RepositoryInfo{CloneInfo: info}, nil\n+\treturn RepositoryInfo{RepositoryVisibility: getBitbucketServerRepositoryVisibility(holder.Public), CloneInfo: info}, nil\n }\n \n // GetCommitBySha on Bitbucket server\n@@ -522,6 +523,11 @@ func (client *BitbucketServerClient) UnlabelPullRequest(ctx context.Context, own\n \treturn errLabelsNotSupported\n }\n \n+// GetRepositoryEnvironmentInfo on Bitbucket server\n+func (client *BitbucketServerClient) GetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error) {\n+\treturn RepositoryEnvironmentInfo{}, errBitbucketGetRepoEnvironmentInfoNotSupported\n+}\n+\n // Get all projects for which the authenticated user has the PROJECT_VIEW permission\n func (client *BitbucketServerClient) listProjects(bitbucketClient *bitbucketv1.DefaultApiService) ([]string, error) {\n \tvar apiResponse *bitbucketv1.APIResponse\n@@ -553,7 +559,15 @@ func (client *BitbucketServerClient) listProjects(bitbucketClient *bitbucketv1.D\n \n // DownloadFileFromRepo on Bitbucket server\n func (client *BitbucketServerClient) DownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error) {\n-\treturn nil, 0, errBitbucketDownloadFileFromRepoNotSupported\n+\tbitbucketClient, err := client.buildBitbucketClient(ctx)\n+\tif err != nil {\n+\t\treturn nil, 0, err\n+\t}\n+\tresp, err := bitbucketClient.GetContent_11(owner, repository, path, map[string]interface{}{\"at\": branch})\n+\tif err != nil {\n+\t\treturn nil, 0, err\n+\t}\n+\treturn resp.Payload, resp.StatusCode, err\n }\n \n func createPaginationOptions(nextPageStart int) map[string]interface{} {\n@@ -627,3 +641,10 @@ func (client *BitbucketServerClient) mapBitbucketServerCommitToCommitInfo(commit\n func (client *BitbucketServerClient) UploadCodeScanning(ctx context.Context, owner string, repository string, branch string, scanResults string) (string, error) {\n \treturn \"\", errBitbucketCodeScanningNotSupported\n }\n+\n+func getBitbucketServerRepositoryVisibility(public bool) RepositoryVisibility {\n+\tif public {\n+\t\treturn Public\n+\t}\n+\treturn Private\n+}"
+    },
+    {
+      "sha": "e64571dd75ff65483778410ea3f9e2eaa79c43f6",
+      "filename": "vcsclient/bitbucketserver_test.go",
+      "status": "modified",
+      "additions": 45,
+      "deletions": 2,
+      "changes": 47,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketserver_test.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fbitbucketserver_test.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fbitbucketserver_test.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -398,6 +398,7 @@ func TestBitbucketServer_GetRepositoryInfo(t *testing.T) {\n \t\trequire.NoError(t, err)\n \t\trequire.Equal(t,\n \t\t\tRepositoryInfo{\n+\t\t\t\tRepositoryVisibility: Public,\n \t\t\t\tCloneInfo: CloneInfo{\n \t\t\t\t\tHTTP: \"https://bitbucket.org/jfrog/repo-1.git\",\n \t\t\t\t\tSSH:  \"ssh://git@bitbucket.org:jfrog/repo-1.git\",\n@@ -447,6 +448,15 @@ func TestBitbucketServer_UnlabelPullRequest(t *testing.T) {\n \tassert.ErrorIs(t, err, errLabelsNotSupported)\n }\n \n+func TestBitbucketServer_GetRepositoryEnvironmentInfo(t *testing.T) {\n+\tctx := context.Background()\n+\tclient, err := NewClientBuilder(vcsutils.BitbucketServer).Build()\n+\tassert.NoError(t, err)\n+\n+\t_, err = client.GetRepositoryEnvironmentInfo(ctx, owner, repo1, envName)\n+\tassert.ErrorIs(t, err, errBitbucketGetRepoEnvironmentInfoNotSupported)\n+}\n+\n func TestBitbucketServer_GetCommitBySha(t *testing.T) {\n \tctx := context.Background()\n \tsha := \"abcdef0123abcdef4567abcdef8987abcdef6543\"\n@@ -511,12 +521,31 @@ func TestBitbucketServer_UploadCodeScanning(t *testing.T) {\n \n func TestBitbucketServer_DownloadFileFromRepo(t *testing.T) {\n \tctx := context.Background()\n-\tclient, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, \"\", \"unsupportedTest\", createBitbucketServerHandler)\n+\texpectedPayload := []byte(\"hello world\")\n+\tclient, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, expectedPayload, \"/rest/api/1.0/projects/jfrog/repos/repo-1/raw/hello-world?at=branch-1\", createBitbucketServerDownloadFileFromRepositoryHandler)\n \tdefer cleanUp()\n-\t_, _, err := client.DownloadFileFromRepo(ctx, owner, repo1, \"\", \"\")\n+\n+\texpectedStatusCode := 200\n+\tpayload, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo1, branch1, \"hello-world\")\n+\tassert.Equal(t, expectedPayload, payload)\n+\tassert.Equal(t, expectedStatusCode, statusCode)\n+\tassert.NoError(t, err)\n+\n+\tclient = createBadBitbucketServerClient(t)\n+\t_, _, err = client.DownloadFileFromRepo(ctx, owner, repo1, branch1, \"hello-world\")\n+\tassert.Error(t, err)\n+\n+\tclient, cleanUp = createServerAndClient(t, vcsutils.BitbucketServer, true, expectedPayload, \"/rest/api/1.0/projects/jfrog/repos/repo-1/raw/bad-test?at=branch-1\", createBitbucketServerDownloadFileFromRepositoryHandler)\n+\tdefer cleanUp()\n+\t_, _, err = client.DownloadFileFromRepo(ctx, owner, repo1, branch1, \"bad-test\")\n \tassert.Error(t, err)\n }\n \n+func TestBitbucketServer_getRepositoryVisibility(t *testing.T) {\n+\tassert.Equal(t, Public, getBitbucketServerRepositoryVisibility(true))\n+\tassert.Equal(t, Private, getBitbucketServerRepositoryVisibility(false))\n+}\n+\n func createBitbucketServerHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {\n \treturn func(w http.ResponseWriter, r *http.Request) {\n \t\tw.WriteHeader(expectedStatusCode)\n@@ -550,6 +579,20 @@ func createBitbucketServerListRepositoriesHandler(t *testing.T, _ string, _ []by\n \t}\n }\n \n+func createBitbucketServerDownloadFileFromRepositoryHandler(t *testing.T, _ string, expectedResponse []byte, _ int) http.HandlerFunc {\n+\treturn func(w http.ResponseWriter, r *http.Request) {\n+\t\tif r.RequestURI == \"/rest/api/1.0/projects/jfrog/repos/repo-1/raw/hello-world?at=branch-1\" {\n+\t\t\t_, err := w.Write(expectedResponse)\n+\t\t\trequire.NoError(t, err)\n+\t\t\treturn\n+\t\t}\n+\t\tif r.RequestURI == \"/rest/api/1.0/projects/jfrog/repos/repo-1/raw/bad-test?at=branch-1\" {\n+\t\t\tw.WriteHeader(http.StatusNotFound)\n+\t\t\treturn\n+\t\t}\n+\t}\n+}\n+\n func createBitbucketServerWithBodyHandler(t *testing.T, expectedURI string, response []byte, expectedRequestBody []byte,\n \texpectedStatusCode int, expectedHTTPMethod string) http.HandlerFunc {\n \treturn func(writer http.ResponseWriter, request *http.Request) {"
+    },
+    {
+      "sha": "416ca7ac2a5e908d338105d87358f72d8a2a5bb3",
+      "filename": "vcsclient/common_test.go",
+      "status": "modified",
+      "additions": 1,
+      "deletions": 0,
+      "changes": 1,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fcommon_test.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fcommon_test.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fcommon_test.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -25,6 +25,7 @@ var (\n \tbranch1   = \"branch-1\"\n \tbranch2   = \"branch-2\"\n \tlabelName = \"🚀 label-name\"\n+\tenvName   = \"frogbot\"\n )\n \n type createHandlerFunc func(t *testing.T, expectedUri string, response []byte, expectedStatusCode int) http.HandlerFunc"
+    },
+    {
+      "sha": "d4327397ac138eccfc12d7677f66b3e70393f16f",
+      "filename": "vcsclient/github.go",
+      "status": "modified",
+      "additions": 73,
+      "deletions": 6,
+      "changes": 79,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgithub.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgithub.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fgithub.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -4,15 +4,17 @@ import (\n \t\"context\"\n \t\"encoding/json\"\n \t\"fmt\"\n-\t\"github.com/google/go-github/v45/github\"\n-\t\"github.com/grokify/mogo/encoding/base64\"\n-\t\"github.com/jfrog/froggit-go/vcsutils\"\n-\t\"golang.org/x/oauth2\"\n \t\"io\"\n \t\"net/http\"\n \t\"net/url\"\n \t\"strconv\"\n \t\"strings\"\n+\n+\t\"github.com/google/go-github/v45/github\"\n+\t\"github.com/grokify/mogo/encoding/base64\"\n+\t\"github.com/jfrog/froggit-go/vcsutils\"\n+\t\"github.com/mitchellh/mapstructure\"\n+\t\"golang.org/x/oauth2\"\n )\n \n // GitHubClient API version 3\n@@ -340,7 +342,7 @@ func (client *GitHubClient) GetRepositoryInfo(ctx context.Context, owner, reposi\n \tif err != nil {\n \t\treturn RepositoryInfo{}, err\n \t}\n-\treturn RepositoryInfo{CloneInfo: CloneInfo{HTTP: repo.GetCloneURL(), SSH: repo.GetSSHURL()}}, nil\n+\treturn RepositoryInfo{RepositoryVisibility: getGitHubRepositoryVisibility(repo), CloneInfo: CloneInfo{HTTP: repo.GetCloneURL(), SSH: repo.GetSSHURL()}}, nil\n }\n \n // GetCommitBySha on GitHub\n@@ -519,7 +521,7 @@ func (client *GitHubClient) DownloadFileFromRepo(ctx context.Context, owner, rep\n \t\t}\n \t}()\n \tif response != nil && response.StatusCode != http.StatusOK {\n-\t\treturn nil, response.StatusCode, fmt.Errorf(\"expected %d status code while received %d status code\", http.StatusOK, response.StatusCode)\n+\t\treturn nil, response.StatusCode, fmt.Errorf(\"expected %d status code while received %d status code with error:\\n%s\", http.StatusOK, response.StatusCode, err)\n \t}\n \tif err != nil {\n \t\treturn nil, 0, err\n@@ -532,6 +534,56 @@ func (client *GitHubClient) DownloadFileFromRepo(ctx context.Context, owner, rep\n \treturn content, response.StatusCode, nil\n }\n \n+// GetRepositoryEnvironmentInfo on GitHub\n+func (client *GitHubClient) GetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error) {\n+\terr := validateParametersNotBlank(map[string]string{\"owner\": owner, \"repository\": repository, \"name\": name})\n+\tif err != nil {\n+\t\treturn RepositoryEnvironmentInfo{}, err\n+\t}\n+\tghClient, err := client.buildGithubClient(ctx)\n+\tif err != nil {\n+\t\treturn RepositoryEnvironmentInfo{}, err\n+\t}\n+\n+\tenvironment, resp, err := ghClient.Repositories.GetEnvironment(ctx, owner, repository, name)\n+\tif err != nil {\n+\t\treturn RepositoryEnvironmentInfo{}, err\n+\t}\n+\tif err = vcsutils.CheckResponseStatusWithBody(resp.Response, http.StatusOK); err != nil {\n+\t\treturn RepositoryEnvironmentInfo{}, err\n+\t}\n+\n+\treviewers, err := extractGitHubEnvironmentReviewers(environment)\n+\tif err != nil {\n+\t\treturn RepositoryEnvironmentInfo{}, err\n+\t}\n+\n+\treturn RepositoryEnvironmentInfo{\n+\t\tName:      *environment.Name,\n+\t\tUrl:       *environment.URL,\n+\t\tReviewers: reviewers,\n+\t}, err\n+}\n+\n+// Extract code reviewers from environment\n+func extractGitHubEnvironmentReviewers(environment *github.Environment) ([]string, error) {\n+\tvar reviewers []string\n+\tprotectionRules := environment.ProtectionRules\n+\tif protectionRules == nil {\n+\t\treturn reviewers, nil\n+\t}\n+\treviewerStruct := repositoryEnvironmentReviewer{}\n+\tfor _, rule := range protectionRules {\n+\t\tfor _, reviewer := range rule.Reviewers {\n+\t\t\tif err := mapstructure.Decode(reviewer.Reviewer, &reviewerStruct); err != nil {\n+\t\t\t\treturn []string{}, err\n+\t\t\t}\n+\t\t\treviewers = append(reviewers, reviewerStruct.Login)\n+\t\t}\n+\t}\n+\treturn reviewers, nil\n+}\n+\n func createGitHubHook(token, payloadURL string, webhookEvents ...vcsutils.WebhookEvent) *github.Hook {\n \treturn &github.Hook{\n \t\tEvents: getGitHubWebhookEvents(webhookEvents...),\n@@ -557,6 +609,17 @@ func getGitHubWebhookEvents(webhookEvents ...vcsutils.WebhookEvent) []string {\n \treturn events\n }\n \n+func getGitHubRepositoryVisibility(repo *github.Repository) RepositoryVisibility {\n+\tswitch *repo.Visibility {\n+\tcase \"public\":\n+\t\treturn Public\n+\tcase \"internal\":\n+\t\treturn Internal\n+\tdefault:\n+\t\treturn Private\n+\t}\n+}\n+\n func getGitHubCommitState(commitState CommitStatus) string {\n \tswitch commitState {\n \tcase Pass:\n@@ -624,3 +687,7 @@ func packScanningResult(data string) (string, error) {\n \n \treturn compressedScan, err\n }\n+\n+type repositoryEnvironmentReviewer struct {\n+\tLogin string `mapstructure:\"login\"`\n+}"
+    },
+    {
+      "sha": "b849d27da87b10e097d04b87ef3225c6eb422321",
+      "filename": "vcsclient/github_test.go",
+      "status": "modified",
+      "additions": 45,
+      "deletions": 1,
+      "changes": 46,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgithub_test.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgithub_test.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fgithub_test.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -178,6 +178,15 @@ func TestGitHubClient_CreateCommitStatus(t *testing.T) {\n \tassert.Error(t, err)\n }\n \n+func TestGitHubClient_getRepositoryVisibility(t *testing.T) {\n+\tvisibility := \"public\"\n+\tassert.Equal(t, Public, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))\n+\tvisibility = \"internal\"\n+\tassert.Equal(t, Internal, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))\n+\tvisibility = \"private\"\n+\tassert.Equal(t, Private, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))\n+}\n+\n func TestGitHubClient_getGitHubCommitState(t *testing.T) {\n \tassert.Equal(t, \"success\", getGitHubCommitState(Pass))\n \tassert.Equal(t, \"failure\", getGitHubCommitState(Fail))\n@@ -426,7 +435,8 @@ func TestGitHubClient_GetRepositoryInfo(t *testing.T) {\n \trequire.NoError(t, err)\n \trequire.Equal(t,\n \t\tRepositoryInfo{\n-\t\t\tCloneInfo: CloneInfo{HTTP: \"https://github.com/octocat/Hello-World.git\", SSH: \"git@github.com:octocat/Hello-World.git\"},\n+\t\t\tRepositoryVisibility: Public,\n+\t\t\tCloneInfo:            CloneInfo{HTTP: \"https://github.com/octocat/Hello-World.git\", SSH: \"git@github.com:octocat/Hello-World.git\"},\n \t\t},\n \t\tinfo,\n \t)\n@@ -573,6 +583,40 @@ func TestGitHubClient_UploadScanningAnalysis(t *testing.T) {\n \tassert.Error(t, err)\n }\n \n+func TestGitHubClient_GetRepositoryEnvironmentInfo(t *testing.T) {\n+\tctx := context.Background()\n+\n+\tresponse, err := os.ReadFile(filepath.Join(\"testdata\", \"github\", \"repository_environment_response.json\"))\n+\tassert.NoError(t, err)\n+\tclient, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, response, fmt.Sprintf(\"/repos/jfrog/repo-1/environments/%s\", envName), createGitHubHandler)\n+\tdefer cleanUp()\n+\n+\trepositoryEnvironmentInfo, err := client.GetRepositoryEnvironmentInfo(ctx, owner, repo1, envName)\n+\tassert.NoError(t, err)\n+\tassert.Equal(t, envName, repositoryEnvironmentInfo.Name)\n+\tassert.Equal(t, \"https://api.github.com/repos/superfrog/test-repo/environments/frogbot\", repositoryEnvironmentInfo.Url)\n+\tassert.Equal(t, []string{\"superfrog\"}, repositoryEnvironmentInfo.Reviewers)\n+\n+\t_, err = createBadGitHubClient(t).GetRepositoryEnvironmentInfo(ctx, owner, repo1, envName)\n+\tassert.Error(t, err)\n+}\n+\n+func TestGitHubClient_ExtractGitHubEnvironmentReviewers(t *testing.T) {\n+\treviewer1, reviewer2 := \"reviewer-1\", \"reviewer-2\"\n+\tenvironment := &github.Environment{\n+\t\tProtectionRules: []*github.ProtectionRule{{\n+\t\t\tReviewers: []*github.RequiredReviewer{\n+\t\t\t\t{Reviewer: &repositoryEnvironmentReviewer{Login: reviewer1}},\n+\t\t\t\t{Reviewer: &repositoryEnvironmentReviewer{Login: reviewer2}},\n+\t\t\t},\n+\t\t}},\n+\t}\n+\n+\tactualReviewers, err := extractGitHubEnvironmentReviewers(environment)\n+\tassert.NoError(t, err)\n+\tassert.Equal(t, []string{reviewer1, reviewer2}, actualReviewers)\n+}\n+\n func createBadGitHubClient(t *testing.T) VcsClient {\n \tclient, err := NewClientBuilder(vcsutils.GitHub).ApiEndpoint(\"https://bad^endpoint\").Build()\n \trequire.NoError(t, err)"
+    },
+    {
+      "sha": "b6b639b8b4efdb2c878bd78da45146b8ff80f72b",
+      "filename": "vcsclient/gitlab.go",
+      "status": "modified",
+      "additions": 21,
+      "deletions": 4,
+      "changes": 25,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgitlab.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgitlab.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fgitlab.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -210,7 +210,7 @@ func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, reposi\n }\n \n // ListOpenPullRequests on GitLab\n-func (client *GitLabClient) ListOpenPullRequests(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {\n+func (client *GitLabClient) ListOpenPullRequests(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {\n \topenState := \"open\"\n \tallScope := \"all\"\n \toptions := &gitlab.ListMergeRequestsOptions{\n@@ -297,7 +297,7 @@ func (client *GitLabClient) GetRepositoryInfo(ctx context.Context, owner, reposi\n \t\treturn RepositoryInfo{}, err\n \t}\n \n-\treturn RepositoryInfo{CloneInfo: CloneInfo{HTTP: project.HTTPURLToRepo, SSH: project.SSHURLToRepo}}, nil\n+\treturn RepositoryInfo{RepositoryVisibility: getGitLabProjectVisibility(project), CloneInfo: CloneInfo{HTTP: project.HTTPURLToRepo, SSH: project.SSHURLToRepo}}, nil\n }\n \n // GetCommitBySha on GitLab\n@@ -386,15 +386,21 @@ func (client *GitLabClient) UnlabelPullRequest(ctx context.Context, owner, repos\n \treturn err\n }\n \n-func (client *GitLabClient) UploadCodeScanning(ctx context.Context, owner string, repository string, branch string, scanResults string) (string, error) {\n+// UploadCodeScanning on GitLab\n+func (client *GitLabClient) UploadCodeScanning(_ context.Context, _ string, _ string, _ string, _ string) (string, error) {\n \treturn \"\", errGitLabCodeScanningNotSupported\n }\n \n+// GetRepositoryEnvironmentInfo on GitLab\n+func (client *GitLabClient) GetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error) {\n+\treturn RepositoryEnvironmentInfo{}, errGitLabGetRepoEnvironmentInfoNotSupported\n+}\n+\n // DownloadFileFromRepo on GitLab\n func (client *GitLabClient) DownloadFileFromRepo(_ context.Context, owner, repository, branch, path string) ([]byte, int, error) {\n \tfile, response, err := client.glClient.RepositoryFiles.GetFile(getProjectID(owner, repository), path, &gitlab.GetFileOptions{Ref: &branch})\n \tif response != nil && response.StatusCode != http.StatusOK {\n-\t\treturn nil, response.StatusCode, fmt.Errorf(\"expected %d status code while received %d status code\", http.StatusOK, response.StatusCode)\n+\t\treturn nil, response.StatusCode, fmt.Errorf(\"expected %d status code while received %d status code with error:\\n%s\", http.StatusOK, response.StatusCode, err)\n \t}\n \tif err != nil {\n \t\treturn nil, 0, err\n@@ -426,6 +432,17 @@ func createProjectHook(branch string, payloadURL string, webhookEvents ...vcsuti\n \treturn options\n }\n \n+func getGitLabProjectVisibility(project *gitlab.Project) RepositoryVisibility {\n+\tswitch project.Visibility {\n+\tcase gitlab.PublicVisibility:\n+\t\treturn Public\n+\tcase gitlab.InternalVisibility:\n+\t\treturn Internal\n+\tdefault:\n+\t\treturn Private\n+\t}\n+}\n+\n func getGitLabCommitState(commitState CommitStatus) string {\n \tswitch commitState {\n \tcase Pass:"
+    },
+    {
+      "sha": "d7226705f788a80e35cb95ffa542849f19bcf456",
+      "filename": "vcsclient/gitlab_test.go",
+      "status": "modified",
+      "additions": 20,
+      "deletions": 3,
+      "changes": 23,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgitlab_test.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgitlab_test.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fgitlab_test.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -332,9 +332,11 @@ func TestGitLabClient_GetRepositoryInfo(t *testing.T) {\n \tresult, err := client.GetRepositoryInfo(ctx, \"diaspora\", \"diaspora-project-site\")\n \trequire.NoError(t, err)\n \trequire.Equal(t,\n-\t\tRepositoryInfo{CloneInfo: CloneInfo{\n-\t\t\tHTTP: \"http://example.com/diaspora/diaspora-project-site.git\",\n-\t\t\tSSH:  \"git@example.com:diaspora/diaspora-project-site.git\"},\n+\t\tRepositoryInfo{\n+\t\t\tRepositoryVisibility: Private,\n+\t\t\tCloneInfo: CloneInfo{\n+\t\t\t\tHTTP: \"http://example.com/diaspora/diaspora-project-site.git\",\n+\t\t\t\tSSH:  \"git@example.com:diaspora/diaspora-project-site.git\"},\n \t\t},\n \t\tresult,\n \t)\n@@ -384,6 +386,12 @@ func TestGitLabClient_GetCommitByShaNotFound(t *testing.T) {\n \tassert.Empty(t, result)\n }\n \n+func TestGitLabClient_getGitLabProjectVisibility(t *testing.T) {\n+\tassert.Equal(t, Public, getGitLabProjectVisibility(&gitlab.Project{Visibility: gitlab.PublicVisibility}))\n+\tassert.Equal(t, Internal, getGitLabProjectVisibility(&gitlab.Project{Visibility: gitlab.InternalVisibility}))\n+\tassert.Equal(t, Private, getGitLabProjectVisibility(&gitlab.Project{Visibility: gitlab.PrivateVisibility}))\n+}\n+\n func TestGitlabClient_getGitlabCommitState(t *testing.T) {\n \tassert.Equal(t, \"success\", getGitLabCommitState(Pass))\n \tassert.Equal(t, \"failed\", getGitLabCommitState(Fail))\n@@ -454,6 +462,15 @@ func TestGitlabClient_UploadCodeScanning(t *testing.T) {\n \tassert.Error(t, err)\n }\n \n+func TestGitlabClient_GetRepositoryEnvironmentInfo(t *testing.T) {\n+\tctx := context.Background()\n+\tclient, cleanUp := createServerAndClient(t, vcsutils.GitLab, true, \"\", \"unsupportedTest\", createGitLabHandler)\n+\tdefer cleanUp()\n+\n+\t_, err := client.GetRepositoryEnvironmentInfo(ctx, owner, repo1, envName)\n+\tassert.ErrorIs(t, err, errGitLabGetRepoEnvironmentInfoNotSupported)\n+}\n+\n func createGitLabHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {\n \treturn func(w http.ResponseWriter, r *http.Request) {\n \t\tif r.RequestURI == \"/api/v4/\" {"
+    },
+    {
+      "sha": "47d06e236246b3a66af732eef905391c0c3c857f",
+      "filename": "vcsclient/gitlabcommon.go",
+      "status": "modified",
+      "additions": 1,
+      "deletions": 0,
+      "changes": 1,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgitlabcommon.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fgitlabcommon.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fgitlabcommon.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -5,3 +5,4 @@ import (\n )\n \n var errGitLabCodeScanningNotSupported = errors.New(\"code scanning is not supported on Gitlab\")\n+var errGitLabGetRepoEnvironmentInfoNotSupported = errors.New(\"get repository environment info is currently not supported on Bitbucket\")"
+    },
+    {
+      "sha": "c54200dcf1bc16c792a5c4ba99adf8ab67ca2655",
+      "filename": "vcsclient/testdata/github/repository_environment_response.json",
+      "status": "added",
+      "additions": 42,
+      "deletions": 0,
+      "changes": 42,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Ftestdata%2Fgithub%2Frepository_environment_response.json",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Ftestdata%2Fgithub%2Frepository_environment_response.json",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Ftestdata%2Fgithub%2Frepository_environment_response.json?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -0,0 +1,42 @@\n+{\n+    \"id\": 458044593,\n+    \"node_id\": \"EN_kwDOFo0fF84bTTSx\",\n+    \"name\": \"frogbot\",\n+    \"url\": \"https://api.github.com/repos/superfrog/test-repo/environments/frogbot\",\n+    \"html_url\": \"https://github.com/superfrog/test-repo/deployments/activity_log?environments_filter=frogbot\",\n+    \"created_at\": \"2022-04-07T05:57:50Z\",\n+    \"updated_at\": \"2022-04-07T05:57:50Z\",\n+    \"protection_rules\": [\n+        {\n+            \"id\": 210348,\n+            \"node_id\": \"GA_kwDOFo0fF84AAzWs\",\n+            \"type\": \"required_reviewers\",\n+            \"reviewers\": [\n+                {\n+                    \"type\": \"User\",\n+                    \"reviewer\": {\n+                        \"login\": \"superfrog\",\n+                        \"id\": 11367982,\n+                        \"node_id\": \"MDQ6VXNlcjExMzY3OTgy\",\n+                        \"avatar_url\": \"https://avatars.githubusercontent.com/u/11367982?v=4\",\n+                        \"gravatar_id\": \"\",\n+                        \"url\": \"https://api.github.com/users/superfrog\",\n+                        \"html_url\": \"https://github.com/superfrog\",\n+                        \"followers_url\": \"https://api.github.com/users/superfrog/followers\",\n+                        \"following_url\": \"https://api.github.com/users/superfrog/following{/other_user}\",\n+                        \"gists_url\": \"https://api.github.com/users/superfrog/gists{/gist_id}\",\n+                        \"starred_url\": \"https://api.github.com/users/superfrog/starred{/owner}{/repo}\",\n+                        \"subscriptions_url\": \"https://api.github.com/users/superfrog/subscriptions\",\n+                        \"organizations_url\": \"https://api.github.com/users/superfrog/orgs\",\n+                        \"repos_url\": \"https://api.github.com/users/superfrog/repos\",\n+                        \"events_url\": \"https://api.github.com/users/superfrog/events{/privacy}\",\n+                        \"received_events_url\": \"https://api.github.com/users/superfrog/received_events\",\n+                        \"type\": \"User\",\n+                        \"site_admin\": false\n+                    }\n+                }\n+            ]\n+        }\n+    ],\n+    \"deployment_branch_policy\": null\n+}\n\\ No newline at end of file"
+    },
+    {
+      "sha": "3cae8d4de1898a5d528d42fae36fbe3a2acfef4b",
+      "filename": "vcsclient/vcsclient.go",
+      "status": "modified",
+      "additions": 24,
+      "deletions": 1,
+      "changes": 25,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fvcsclient.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fvcsclient.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fvcsclient.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -33,6 +33,18 @@ const (\n \tReadWrite\n )\n \n+// RepositoryVisibility the visibility level of the repository\n+type RepositoryVisibility int\n+\n+const (\n+\t// Open to public\n+\tPublic RepositoryVisibility = iota\n+\t// Open to organization\n+\tInternal\n+\t// Open to user\n+\tPrivate\n+)\n+\n // VcsInfo is the connection details of the VcsClient to communicate with the server\n type VcsInfo struct {\n \tAPIEndpoint string\n@@ -42,6 +54,13 @@ type VcsInfo struct {\n \tProject string\n }\n \n+// RepositoryEnvironmentInfo is the environment details configured for a repository\n+type RepositoryEnvironmentInfo struct {\n+\tName      string\n+\tUrl       string\n+\tReviewers []string\n+}\n+\n // VcsClient is a base class of all Vcs clients - GitHub, GitLab, Bitbucket server and cloud clients\n type VcsClient interface {\n \t// TestConnection Returns nil if connection and authorization established successfully\n@@ -187,6 +206,9 @@ type VcsClient interface {\n \t// branch        - The name of the branch\n \t// path  \t\t - The path to the requested file\n \tDownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error)\n+\n+\t// GetRepositoryEnvironmentInfo Gets the environment info configured for a repository\n+\tGetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error)\n }\n \n // CommitInfo contains the details of a commit\n@@ -226,7 +248,8 @@ type BranchInfo struct {\n \n // RepositoryInfo contains general information about repository.\n type RepositoryInfo struct {\n-\tCloneInfo CloneInfo\n+\tCloneInfo            CloneInfo\n+\tRepositoryVisibility RepositoryVisibility\n }\n \n // CloneInfo contains URLs that can be used to clone the repository."
+    },
+    {
+      "sha": "3cae8d4de1898a5d528d42fae36fbe3a2acfef4b",
+      "previous_filename": "vcsclient/vcsclient_old.go",
+      "filename": "vcsclient/vcsclient.go",
+      "status": "modified",
+      "additions": 24,
+      "deletions": 1,
+      "changes": 25,
+      "blob_url": "https://github.com/jfrog/froggit-go/blob/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fvcsclient.go",
+      "raw_url": "https://github.com/jfrog/froggit-go/raw/d41c3fcff4ea7d18e753977f5d63d5003becaa2f/vcsclient%2Fvcsclient.go",
+      "contents_url": "https://api.github.com/repos/jfrog/froggit-go/contents/vcsclient%2Fvcsclient.go?ref=d41c3fcff4ea7d18e753977f5d63d5003becaa2f",
+      "patch": "@@ -33,6 +33,18 @@ const (\n \tReadWrite\n )\n \n+// RepositoryVisibility the visibility level of the repository\n+type RepositoryVisibility int\n+\n+const (\n+\t// Open to public\n+\tPublic RepositoryVisibility = iota\n+\t// Open to organization\n+\tInternal\n+\t// Open to user\n+\tPrivate\n+)\n+\n // VcsInfo is the connection details of the VcsClient to communicate with the server\n type VcsInfo struct {\n \tAPIEndpoint string\n@@ -42,6 +54,13 @@ type VcsInfo struct {\n \tProject string\n }\n \n+// RepositoryEnvironmentInfo is the environment details configured for a repository\n+type RepositoryEnvironmentInfo struct {\n+\tName      string\n+\tUrl       string\n+\tReviewers []string\n+}\n+\n // VcsClient is a base class of all Vcs clients - GitHub, GitLab, Bitbucket server and cloud clients\n type VcsClient interface {\n \t// TestConnection Returns nil if connection and authorization established successfully\n@@ -187,6 +206,9 @@ type VcsClient interface {\n \t// branch        - The name of the branch\n \t// path  \t\t - The path to the requested file\n \tDownloadFileFromRepo(ctx context.Context, owner, repository, branch, path string) ([]byte, int, error)\n+\n+\t// GetRepositoryEnvironmentInfo Gets the environment info configured for a repository\n+\tGetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error)\n }\n \n // CommitInfo contains the details of a commit\n@@ -226,7 +248,8 @@ type BranchInfo struct {\n \n // RepositoryInfo contains general information about repository.\n type RepositoryInfo struct {\n-\tCloneInfo CloneInfo\n+\tCloneInfo            CloneInfo\n+\tRepositoryVisibility RepositoryVisibility\n }\n \n // CloneInfo contains URLs that can be used to clone the repository."
+    }
+  ]
+}

--- a/vcsclient/testdata/gitlab/compare_commits.json
+++ b/vcsclient/testdata/gitlab/compare_commits.json
@@ -1,0 +1,65 @@
+{
+  "commit": {
+    "id": "1c0a893703a70558fcf7bb13348847a1302b2c49",
+    "short_id": "1c0a8937",
+    "created_at": "2023-02-13T10:18:53.000+01:00",
+    "parent_ids": ["9cee818844e23dfa5922155d113a950ff86ff2e7"],
+    "title": "Update Slack notes",
+    "message": "Update Slack notes\n",
+    "author_name": "Ashraf Khamis",
+    "author_email": "akhamis@gitlab.com",
+    "authored_date": "2023-02-13T10:18:53.000+01:00",
+    "committer_name": "Ashraf Khamis",
+    "committer_email": "akhamis@gitlab.com",
+    "committed_date": "2023-02-13T10:18:53.000+01:00",
+    "trailers": {},
+    "web_url": "https://gitlab.com/gitlab-org/gitlab/-/commit/1c0a893703a70558fcf7bb13348847a1302b2c49"
+  },
+  "commits": [{
+    "id": "1c0a893703a70558fcf7bb13348847a1302b2c49",
+    "short_id": "1c0a8937",
+    "created_at": "2023-02-13T10:18:53.000+01:00",
+    "parent_ids": ["9cee818844e23dfa5922155d113a950ff86ff2e7"],
+    "title": "Update Slack notes",
+    "message": "Update Slack notes\n",
+    "author_name": "Ashraf Khamis",
+    "author_email": "akhamis@gitlab.com",
+    "authored_date": "2023-02-13T10:18:53.000+01:00",
+    "committer_name": "Ashraf Khamis",
+    "committer_email": "akhamis@gitlab.com",
+    "committed_date": "2023-02-13T10:18:53.000+01:00",
+    "trailers": {},
+    "web_url": "https://gitlab.com/gitlab-org/gitlab/-/commit/1c0a893703a70558fcf7bb13348847a1302b2c49"
+  }],
+  "diffs": [{
+    "diff": "@@ -7,11 +7,11 @@ info: To determine the technical writer assigned to the Stage/Group associated w\n # GitLab for Slack app **(FREE SAAS)**\n \n NOTE:\n-The GitLab for Slack app is only configurable for GitLab SaaS customers.\n-Self-managed GitLab customers should configure\n-[Slack slash commands](slack_slash_commands.md) and [Slack notifications](slack.md) instead. See\n-[Slack application integration for self-managed instances](https://gitlab.com/groups/gitlab-org/-/epics/1211)\n-for our plans to make the app configurable for all GitLab installations.\n+This feature is only configurable on GitLab.com.\n+For self-managed GitLab instances, use\n+[Slack slash commands](slack_slash_commands.md) and [Slack notifications](slack.md) instead.\n+For more information about our plans to make the app configurable for all GitLab installations,\n+see [epic 1211](https://gitlab.com/groups/gitlab-org/-/epics/1211).\n \n Slack provides a native application that you can enable with your project's\n integrations on GitLab.com.\n",
+    "new_path": "doc/user/project/integrations/gitlab_slack_application.md",
+    "old_path": "doc/user/project/integrations/gitlab_slack_application.md",
+    "a_mode": "100644",
+    "b_mode": "100644",
+    "new_file": false,
+    "renamed_file": false,
+    "deleted_file": false
+  }, {
+    "diff": "@@ -7,10 +7,10 @@ info: To determine the technical writer assigned to the Stage/Group associated w\n # Slack notifications integration **(FREE)**\n \n WARNING:\n-This feature was [deprecated](https://gitlab.com/gitlab-org/gitlab/-/issues/372411) for GitLab SaaS customers\n+This feature was [deprecated](https://gitlab.com/gitlab-org/gitlab/-/issues/372411) on GitLab.com\n in GitLab 15.10 and is [planned for removal](https://gitlab.com/groups/gitlab-org/-/epics/8673).\n-GitLab SaaS customers can use the [GitLab for Slack app](gitlab_slack_application.md) instead.\n-Self-managed GitLab customers can continue to use this feature.\n+Use the [GitLab for Slack app](gitlab_slack_application.md) instead.\n+On self-managed GitLab instances, you can continue to use this feature.\n \n The Slack notifications integration enables your GitLab project to send events\n (such as issue creation) to your existing Slack team as notifications. Setting up\n",
+    "new_path": "doc/user/project/integrations/slack.md",
+    "old_path": "doc/user/project/integrations/slack.md",
+    "a_mode": "100644",
+    "b_mode": "100644",
+    "new_file": false,
+    "renamed_file": false,
+    "deleted_file": false
+  }, {
+    "diff": "@@ -6,6 +6,10 @@ info: To determine the technical writer assigned to the Stage/Group associated w\n \n # Slack slash commands **(FREE SELF)**\n \n+NOTE:\n+This feature is only configurable on self-managed GitLab instances.\n+For GitLab.com, use the [GitLab for Slack app](gitlab_slack_application.md) instead.\n+\n If you want to control and view GitLab content while you're\n working in Slack, you can use Slack slash commands.\n To use Slack slash commands, you must configure both Slack and GitLab.\n@@ -13,9 +17,6 @@ To use Slack slash commands, you must configure both Slack and GitLab.\n GitLab can also send events (for example, `issue created`) to Slack as notifications.\n The [Slack notifications service](slack.md) is configured separately.\n \n-NOTE:\n-The Slack slash commands are only configurable on self-managed GitLab instances. For GitLab.com, use the [GitLab for Slack app](gitlab_slack_application.md) instead.\n-\n ## Configure GitLab and Slack\n \n Slack slash command integrations\n",
+    "new_path": "doc/user/project/integrations/slack_slash_commands.md",
+    "old_path": "doc/user/project/integrations/slack_slash_commands_2.md",
+    "a_mode": "100644",
+    "b_mode": "100644",
+    "new_file": false,
+    "renamed_file": false,
+    "deleted_file": false
+  }],
+  "compare_timeout": false,
+  "compare_same_ref": false,
+  "web_url": "https://gitlab.com/gitlab-org/gitlab/-/compare/9cee818844e23dfa5922155d113a950ff86ff2e7...1c0a893703a70558fcf7bb13348847a1302b2c49"
+}

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -209,6 +209,12 @@ type VcsClient interface {
 
 	// GetRepositoryEnvironmentInfo Gets the environment info configured for a repository
 	GetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error)
+	// GetModifiedFiles returns list of file names modified between two VCS references
+	// owner         - User or organization
+	// repository    - VCS repository name
+	// refBefore     - A VCS reference: commit SHA, branch name, tag name
+	// refAfter      - A VCS reference: commit SHA, branch name, tag name
+	GetModifiedFiles(ctx context.Context, owner, repository, refBefore, refAfter string) ([]string, error)
 }
 
 // CommitInfo contains the details of a commit
@@ -269,7 +275,7 @@ type LabelInfo struct {
 }
 
 func validateParametersNotBlank(paramNameValueMap map[string]string) error {
-	errorMessages := make([]string, 0)
+	var errorMessages []string
 	for k, v := range paramNameValueMap {
 		if strings.TrimSpace(v) == "" {
 			errorMessages = append(errorMessages, fmt.Sprintf("required parameter '%s' is missing", k))

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -162,6 +162,11 @@ func DefaultIfNotNil[T any](val *T) T {
 	return *val
 }
 
+// PointerOf returns pointer to the provided value if it is not nil.
+func PointerOf[T any](v T) *T {
+	return &v
+}
+
 // AddBranchPrefix adds a branchPrefix to a branch name if it is not already present.
 func AddBranchPrefix(branch string) string {
 	if !strings.HasPrefix(branch, branchPrefix) {

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -2,6 +2,7 @@ package vcsutils
 
 import (
 	"github.com/go-git/go-git/v5"
+	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"os"
@@ -191,4 +192,9 @@ func TestCreateDotGitFolderWithoutRemote(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir2)
 	assert.Error(t, CreateDotGitFolderWithRemote(dir2, "", "fakeurl"))
+}
+
+func TestPointerOf(t *testing.T) {
+	require.Equal(t, 5, *PointerOf(5))
+	require.Equal(t, "some", *PointerOf("some"))
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---

A new method GetModifiedFiles is added. It returns paths of the files modified between two references (tags, commits, branches) using 3-dot diff range flow.
It is needed by the https://jfrog-int.atlassian.net/browse/INTG-389