### PR TITLE
Add .git initialization on DownloadRepository for GitLab

### DIFF
--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -193,7 +193,8 @@ func (client *GitLabClient) DownloadRepository(ctx context.Context, owner, repos
 		return err
 	}
 	client.logger.Info("extracted repository successfully")
-	return nil
+	return vcsutils.CreateDotGitFolderWithRemote(localPath, "origin",
+		fmt.Sprintf("https://gitlab.com/%s/%s.git", owner, repository))
 }
 
 // CreatePullRequest on GitLab
@@ -394,7 +395,7 @@ func (client *GitLabClient) UploadCodeScanning(_ context.Context, _ string, _ st
 }
 
 // GetRepositoryEnvironmentInfo on GitLab
-func (client *GitLabClient) GetRepositoryEnvironmentInfo(ctx context.Context, owner, repository, name string) (RepositoryEnvironmentInfo, error) {
+func (client *GitLabClient) GetRepositoryEnvironmentInfo(_ context.Context, _, _, _ string) (RepositoryEnvironmentInfo, error) {
 	return RepositoryEnvironmentInfo{}, errGitLabGetRepoEnvironmentInfoNotSupported
 }
 

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -146,8 +146,9 @@ func TestGitLabClient_DownloadRepository(t *testing.T) {
 	require.NoError(t, err)
 	fileinfo, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	assert.Len(t, fileinfo, 1)
-	assert.Equal(t, "README.md", fileinfo[0].Name())
+	assert.Len(t, fileinfo, 2)
+	assert.Equal(t, ".git", fileinfo[0].Name())
+	assert.Equal(t, "README.md", fileinfo[1].Name())
 }
 
 func TestGitLabClient_DownloadFileFromRepo(t *testing.T) {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
