### PR TITLE
Bitbucket - get modified files for commits (fix order of parameters)

### DIFF
--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -490,8 +490,8 @@ func (client *BitbucketCloudClient) GetModifiedFiles(ctx context.Context, owner,
 		RepoSlug: repository,
 		// We use 2 dots for spec because of the case described at the page:
 		// https://developer.atlassian.com/cloud/bitbucket/rest/api-group-commits/#two-commit-spec
-		// As there is no `topic` set it will be treated as `refBefore...refAfter` actually.
-		Spec:    refBefore + ".." + refAfter,
+		// As there is no `topic` set it will be treated as `refAfter...refBefore` actually.
+		Spec:    refAfter + ".." + refBefore,
 		Renames: true,
 		Merge:   true,
 	}

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -453,7 +453,7 @@ func TestBitbucketCloudClient_GetModifiedFiles(t *testing.T) {
 		assert.NoError(t, err)
 
 		client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.BitbucketCloud, true, response,
-			fmt.Sprintf("/repositories/%s/%s/diffstat/sha-1..sha-2?page=1", owner, repo1), http.StatusOK,
+			fmt.Sprintf("/repositories/%s/%s/diffstat/sha-2..sha-1?page=1", owner, repo1), http.StatusOK,
 			createBitbucketCloudHandler)
 		defer cleanUp()
 
@@ -480,7 +480,7 @@ func TestBitbucketCloudClient_GetModifiedFiles(t *testing.T) {
 			vcsutils.BitbucketCloud,
 			true,
 			nil,
-			fmt.Sprintf("/repositories/%s/%s/diffstat/sha-1..sha-2?page=1", owner, repo1),
+			fmt.Sprintf("/repositories/%s/%s/diffstat/sha-2..sha-1?page=1", owner, repo1),
 			http.StatusInternalServerError,
 			createBitbucketCloudHandler,
 		)

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -673,7 +673,7 @@ func (client *BitbucketServerClient) GetModifiedFiles(ctx context.Context, owner
 		return nil, err
 	}
 
-	params := map[string]interface{}{"contextLines": int32(0), "from": refBefore, "to": refAfter}
+	params := map[string]interface{}{"contextLines": int32(0), "from": refAfter, "to": refBefore}
 	resp, err := bitbucketClient.StreamDiff_37(owner, repository, "", params)
 	if err != nil {
 		return nil, err

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -558,7 +558,7 @@ func TestBitbucketServerClient_GetModifiedFiles(t *testing.T) {
 			vcsutils.BitbucketServer,
 			false,
 			response,
-			"/rest/api/1.0/projects/jfrog/repos/repo-1/compare/diff?contextLines=0&from=sha-1&to=sha-2",
+			"/rest/api/1.0/projects/jfrog/repos/repo-1/compare/diff?contextLines=0&from=sha-2&to=sha-1",
 			http.StatusOK,
 			nil,
 			http.MethodGet,
@@ -589,7 +589,7 @@ func TestBitbucketServerClient_GetModifiedFiles(t *testing.T) {
 			vcsutils.BitbucketServer,
 			true,
 			nil,
-			"/rest/api/1.0/projects/jfrog/repos/repo-1/compare/diff?contextLines=0&from=sha-1&to=sha-2",
+			"/rest/api/1.0/projects/jfrog/repos/repo-1/compare/diff?contextLines=0&from=sha-2&to=sha-1",
 			http.StatusInternalServerError,
 			createBitbucketServerHandler,
 		)


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
