### PR TITLE
Extend WebhookInfo with additional information about Pull Requests

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jfrog/gofrog/datastructures"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/git"
-	"github.com/mitchellh/mapstructure"
 	"io"
 	"net/http"
 	"os"
@@ -461,12 +460,12 @@ func (client *AzureReposClient) GetModifiedFiles(ctx context.Context, _, reposit
 		}
 
 		for _, anyChange := range changes {
-			change, err := remapFields[git.GitChange](anyChange, "json")
+			change, err := vcsutils.RemapFields[git.GitChange](anyChange, "json")
 			if err != nil {
 				return nil, err
 			}
 
-			changedItem, err := remapFields[git.GitItem](change.Item, "json")
+			changedItem, err := vcsutils.RemapFields[git.GitItem](change.Item, "json")
 			if err != nil {
 				return nil, err
 			}
@@ -485,21 +484,6 @@ func (client *AzureReposClient) GetModifiedFiles(ctx context.Context, _, reposit
 	fileNamesList := fileNamesSet.ToSlice()
 	sort.Strings(fileNamesList)
 	return fileNamesList, nil
-}
-
-// remapFields creates an instance of the T type and copies data from src parameter to it
-// by mapping fields based on the tags with tagName (if not provided 'mapstructure' tag is used).
-func remapFields[T any](src any, tagName string) (T, error) {
-	var dst T
-	if changeDecoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		TagName: tagName,
-		Result:  &dst,
-	}); err != nil {
-		return dst, err
-	} else if err := changeDecoder.Decode(src); err != nil {
-		return dst, err
-	}
-	return dst, nil
 }
 
 // mapStatusToString maps commit status enum to string, specific for azure.

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -313,11 +313,11 @@ func (client *BitbucketCloudClient) ListOpenPullRequests(ctx context.Context, ow
 	if err != nil {
 		return
 	}
-	parsedPullRequests, err := extractPullRequestsFromResponse(pullRequests)
+	parsedPullRequests, err := vcsutils.RemapFields[pullRequestsResponse](pullRequests, "json")
 	if err != nil {
 		return
 	}
-	return mapBitbucketCloudPullRequestToPullRequestInfo(parsedPullRequests), nil
+	return mapBitbucketCloudPullRequestToPullRequestInfo(&parsedPullRequests), nil
 }
 
 // AddPullRequestComment on Bitbucket cloud
@@ -353,11 +353,11 @@ func (client *BitbucketCloudClient) ListPullRequestComments(ctx context.Context,
 	if err != nil {
 		return
 	}
-	parsedComments, err := extractCommentsFromResponse(comments)
+	parsedComments, err := vcsutils.RemapFields[commentsResponse](comments, "json")
 	if err != nil {
 		return
 	}
-	return mapBitbucketCloudCommentToCommentInfo(parsedComments), nil
+	return mapBitbucketCloudCommentToCommentInfo(&parsedComments), nil
 }
 
 // GetLatestCommit on Bitbucket cloud
@@ -381,7 +381,7 @@ func (client *BitbucketCloudClient) GetLatestCommit(ctx context.Context, owner, 
 	if err != nil {
 		return CommitInfo{}, err
 	}
-	parsedCommits, err := extractCommitFromResponse(commits)
+	parsedCommits, err := vcsutils.RemapFields[commitResponse](commits, "json")
 	if err != nil {
 		return CommitInfo{}, err
 	}
@@ -450,7 +450,7 @@ func (client *BitbucketCloudClient) GetCommitBySha(ctx context.Context, owner, r
 	if err != nil {
 		return CommitInfo{}, err
 	}
-	parsedCommit, err := extractCommitDetailsFromResponse(commit)
+	parsedCommit, err := vcsutils.RemapFields[commitDetails](commit, "json")
 	if err != nil {
 		return CommitInfo{}, err
 	}
@@ -544,39 +544,6 @@ func (client *BitbucketCloudClient) GetModifiedFiles(ctx context.Context, owner,
 	fileNamesList := fileNamesSet.ToSlice()
 	sort.Strings(fileNamesList)
 	return fileNamesList, nil
-}
-
-func extractCommitFromResponse(commits interface{}) (*commitResponse, error) {
-	var res commitResponse
-	err := extractStructFromResponse(commits, &res)
-	return &res, err
-}
-
-func extractCommitDetailsFromResponse(commit interface{}) (commitDetails, error) {
-	var res commitDetails
-	err := extractStructFromResponse(commit, &res)
-	return res, err
-}
-
-func extractCommentsFromResponse(comments interface{}) (*commentsResponse, error) {
-	var res commentsResponse
-	err := extractStructFromResponse(comments, &res)
-	return &res, err
-}
-
-func extractPullRequestsFromResponse(pullRequests interface{}) (*pullRequestsResponse, error) {
-	var res pullRequestsResponse
-	err := extractStructFromResponse(pullRequests, &res)
-	return &res, err
-}
-
-func extractStructFromResponse(response, aStructPointer interface{}) error {
-	b, err := json.Marshal(response)
-	if err != nil {
-		return err
-	}
-	err = json.Unmarshal(b, aStructPointer)
-	return err
 }
 
 type pullRequestsResponse struct {

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -692,7 +692,7 @@ func (client *BitbucketServerClient) GetModifiedFiles(ctx context.Context, owner
 		return nil, err
 	}
 
-	dst, err := remapFields[diffPayload](resp.Values, "")
+	dst, err := vcsutils.RemapFields[diffPayload](resp.Values, "")
 	if err != nil {
 		return nil, err
 	}

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -10,11 +10,13 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/google/uuid"
+	"github.com/mitchellh/mapstructure"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 const RemoteName = "origin"
@@ -294,4 +296,21 @@ func CreateDotGitFolderWithRemote(path, remoteName, remoteUrl string) error {
 
 func GetGenericGitRemoteUrl(apiEndpoint, owner, repo string) string {
 	return fmt.Sprintf("%s/%s/%s.git", strings.TrimSuffix(apiEndpoint, "/"), owner, repo)
+}
+
+// RemapFields creates an instance of the T type and copies data from src parameter to it
+// by mapping fields based on the tags with tagName (if not provided 'mapstructure' tag is used)
+// using 'mapstructure' library.
+func RemapFields[T any](src any, tagName string) (T, error) {
+	var dst T
+	if changeDecoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName:    tagName,
+		Result:     &dst,
+		DecodeHook: mapstructure.StringToTimeHookFunc(time.RFC3339),
+	}); err != nil {
+		return dst, err
+	} else if err := changeDecoder.Decode(src); err != nil {
+		return dst, err
+	}
+	return dst, nil
 }

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -259,4 +260,18 @@ func TestGetGenericGitRemoteUrl(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, GetGenericGitRemoteUrl(tc.apiEndpoint, tc.owner, tc.repo))
 		})
 	}
+}
+
+func TestRemapFields(t *testing.T) {
+	type destination struct {
+		Name      string    `some:"n_ame"`
+		Birthdate time.Time `some:"B_day"`
+		High      int       `json:"high"`
+	}
+
+	date := time.Date(2020, 10, 9, 8, 7, 6, 0, time.UTC)
+	src := map[string]any{"n_ame": "John", "B_day": date.Format(time.RFC3339)}
+	result, err := RemapFields[destination](src, "some")
+	require.NoError(t, err)
+	require.Equal(t, destination{Name: "John", Birthdate: date}, result)
 }

--- a/vcsutils/webhookparser/bitbucketcloud_test.go
+++ b/vcsutils/webhookparser/bitbucketcloud_test.go
@@ -65,12 +65,14 @@ func TestBitbucketCloudParseIncomingPushWebhook(t *testing.T) {
 }
 
 func TestBitbucketCloudParseIncomingPrWebhook(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name              string
-		payloadFilename   string
-		eventHeader       string
-		expectedTime      int64
-		expectedEventType vcsutils.WebhookEvent
+		name                string
+		payloadFilename     string
+		eventHeader         string
+		expectedTime        int64
+		expectedEventType   vcsutils.WebhookEvent
+		expectedPullRequest *WebhookInfoPullRequest
 	}{
 		{
 			name:              "create",
@@ -78,6 +80,34 @@ func TestBitbucketCloudParseIncomingPrWebhook(t *testing.T) {
 			eventHeader:       "pullrequest:created",
 			expectedTime:      bitbucketCloudPrCreateExpectedTime,
 			expectedEventType: vcsutils.PrOpened,
+			expectedPullRequest: &WebhookInfoPullRequest{
+				ID:         bitbucketCloudExpectedPrID,
+				Title:      "Dev",
+				CompareUrl: "https://bitbucket.org/yahavi/hello-world/pull-requests/2",
+				Timestamp:  1630831665,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					AvatarUrl: "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?d=https%3A%2F%2F" +
+						"avatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FYI-5.png",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "fa8c303777d0",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "363994ee7c2e",
+			},
 		},
 		{
 			name:              "update",
@@ -85,6 +115,34 @@ func TestBitbucketCloudParseIncomingPrWebhook(t *testing.T) {
 			eventHeader:       "pullrequest:updated",
 			expectedTime:      bitbucketCloudPrUpdateExpectedTime,
 			expectedEventType: vcsutils.PrEdited,
+			expectedPullRequest: &WebhookInfoPullRequest{
+				ID:         bitbucketCloudExpectedPrID,
+				Title:      "Dev",
+				CompareUrl: "https://bitbucket.org/yahavi/hello-world/pull-requests/2",
+				Timestamp:  1630844170,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					AvatarUrl: "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?d=https%3A%2F%2F" +
+						"avatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FYI-5.png",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "78c315141e83",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "1147000c51dc",
+			},
 		},
 		{
 			name:              "merge",
@@ -92,6 +150,34 @@ func TestBitbucketCloudParseIncomingPrWebhook(t *testing.T) {
 			eventHeader:       "pullrequest:fulfilled",
 			expectedTime:      bitbucketCloudPrMergeExpectedTime,
 			expectedEventType: vcsutils.PrMerged,
+			expectedPullRequest: &WebhookInfoPullRequest{
+				ID:         bitbucketCloudExpectedPrID,
+				Title:      "Dev",
+				CompareUrl: "https://bitbucket.org/yahavi/hello-world/pull-requests/2",
+				Timestamp:  1638783257,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					AvatarUrl: "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?d=https%3A%2F%2F" +
+						"avatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FYI-5.png",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "78c315141e83",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "1147000c51dc",
+			},
 		},
 		{
 			name:              "close",
@@ -99,6 +185,34 @@ func TestBitbucketCloudParseIncomingPrWebhook(t *testing.T) {
 			eventHeader:       "pullrequest:rejected",
 			expectedTime:      bitbucketCloudPrCloseExpectedTime,
 			expectedEventType: vcsutils.PrRejected,
+			expectedPullRequest: &WebhookInfoPullRequest{
+				ID:         bitbucketCloudExpectedPrID,
+				Title:      "Dev",
+				CompareUrl: "https://bitbucket.org/yahavi/hello-world/pull-requests/2",
+				Timestamp:  1638784487,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					AvatarUrl: "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?d=https%3A%2F%2F" +
+						"avatar-management--avatars.us-west-2.prod.public.atl-paas.net%2Finitials%2FYI-5.png",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "78c315141e83",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "1147000c51dc",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -131,6 +245,7 @@ func TestBitbucketCloudParseIncomingPrWebhook(t *testing.T) {
 			assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 			assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 			assert.Equal(t, tt.expectedEventType, actual.Event)
+			assert.Equal(t, tt.expectedPullRequest, actual.PullRequest)
 		})
 	}
 }

--- a/vcsutils/webhookparser/bitbucketserver_test.go
+++ b/vcsutils/webhookparser/bitbucketserver_test.go
@@ -78,13 +78,28 @@ func TestBitbucketServerParseIncomingPushWebhook(t *testing.T) {
 }
 
 func TestBitbucketServerParseIncomingPrWebhook(t *testing.T) {
+	author := WebHookInfoUser{
+		Login:       "yahavi",
+		DisplayName: "Yahav Itzhak",
+		Email:       "yahavi@jfrog.com",
+		AvatarUrl:   "https://git.acme.info/users/yahavi",
+	}
+
+	repository := WebHookInfoRepoDetails{
+		Name:  "hello-world",
+		Owner: "~YAHAVI",
+	}
+
+	const title = "Update README.md"
+	const href = "https://git.acme.info/users/yahavi/repos/hello-world/pull-requests/3"
 	tests := []struct {
-		name              string
-		payloadFilename   string
-		eventHeader       string
-		payloadSha        string
-		expectedTime      int64
-		expectedEventType vcsutils.WebhookEvent
+		name                    string
+		payloadFilename         string
+		eventHeader             string
+		payloadSha              string
+		expectedTime            int64
+		expectedEventType       vcsutils.WebhookEvent
+		expectedPullRequestInfo *WebhookInfoPullRequest
 	}{
 		{
 			name:              "create",
@@ -93,6 +108,23 @@ func TestBitbucketServerParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        bitbucketServerPrCreatedSha256,
 			expectedTime:      bitbucketServerPrCreateExpectedTime,
 			expectedEventType: vcsutils.PrOpened,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         bitbucketServerExpectedPrID,
+				Title:      title,
+				CompareUrl: href + "/diff",
+				Timestamp:  1631178661307,
+				Author:     author,
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption:   true,
+				TargetRepository: repository,
+				TargetBranch:     "main",
+				TargetHash:       "929d3054cf60e11a38672966f948bb5d95f48f0e",
+				SourceRepository: repository,
+				SourceBranch:     "dev",
+				SourceHash:       "b3fc2f0a02761b443fca72022a2ac897cc2ceb3a",
+			},
 		},
 		{
 			name:              "update",
@@ -101,6 +133,23 @@ func TestBitbucketServerParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        bitbucketServerPrUpdatedSha256,
 			expectedTime:      bitbucketServerPrUpdateExpectedTime,
 			expectedEventType: vcsutils.PrEdited,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         bitbucketServerExpectedPrID,
+				Title:      title,
+				CompareUrl: href + "/diff",
+				Timestamp:  1631180185186,
+				Author:     author,
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption:   true,
+				TargetRepository: repository,
+				TargetBranch:     "main",
+				TargetHash:       "929d3054cf60e11a38672966f948bb5d95f48f0e",
+				SourceRepository: repository,
+				SourceBranch:     "dev",
+				SourceHash:       "4116e7fd0dffeff395c4697653912ad4c19e1c5b",
+			},
 		},
 		{
 			name:              "merge",
@@ -109,6 +158,23 @@ func TestBitbucketServerParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        bitbucketServerPrMergedSha256,
 			expectedTime:      bitbucketServerPrMergeExpectedTime,
 			expectedEventType: vcsutils.PrMerged,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         bitbucketServerExpectedPrID,
+				Title:      title,
+				CompareUrl: href + "/diff",
+				Timestamp:  1638794461247,
+				Author:     author,
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption:   true,
+				TargetRepository: repository,
+				TargetBranch:     "main",
+				TargetHash:       "929d3054cf60e11a38672966f948bb5d95f48f0e",
+				SourceRepository: repository,
+				SourceBranch:     "dev",
+				SourceHash:       "b3fc2f0a02761b443fca72022a2ac897cc2ceb3a",
+			},
 		},
 		{
 			name:              "decline",
@@ -117,6 +183,23 @@ func TestBitbucketServerParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        bitbucketServerPrDeclinedSha256,
 			expectedTime:      bitbucketServerPrDeclineExpectedTime,
 			expectedEventType: vcsutils.PrRejected,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         bitbucketServerExpectedPrID,
+				Title:      title,
+				CompareUrl: href + "/diff",
+				Timestamp:  1638794521247,
+				Author:     author,
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption:   true,
+				TargetRepository: repository,
+				TargetBranch:     "main",
+				TargetHash:       "929d3054cf60e11a38672966f948bb5d95f48f0e",
+				SourceRepository: repository,
+				SourceBranch:     "dev",
+				SourceHash:       "b3fc2f0a02761b443fca72022a2ac897cc2ceb3a",
+			},
 		},
 		{
 			name:              "delete",
@@ -125,6 +208,23 @@ func TestBitbucketServerParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        bitbucketServerPrDeletedSha256,
 			expectedTime:      bitbucketServerPrDeleteExpectedTime,
 			expectedEventType: vcsutils.PrRejected,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         bitbucketServerExpectedPrID,
+				Title:      title,
+				CompareUrl: href + "/diff",
+				Timestamp:  1638794581247,
+				Author:     author,
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+				},
+				SkipDecryption:   true,
+				TargetRepository: repository,
+				TargetBranch:     "main",
+				TargetHash:       "929d3054cf60e11a38672966f948bb5d95f48f0e",
+				SourceRepository: repository,
+				SourceBranch:     "dev",
+				SourceHash:       "b3fc2f0a02761b443fca72022a2ac897cc2ceb3a",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -158,6 +258,7 @@ func TestBitbucketServerParseIncomingPrWebhook(t *testing.T) {
 			assert.Equal(t, formatOwnerForBitbucketServer(expectedOwner), actual.SourceRepositoryDetails.Owner)
 			assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 			assert.Equal(t, tt.expectedEventType, actual.Event)
+			assert.Equal(t, tt.expectedPullRequestInfo, actual.PullRequest)
 		})
 	}
 }

--- a/vcsutils/webhookparser/github_test.go
+++ b/vcsutils/webhookparser/github_test.go
@@ -86,11 +86,12 @@ func TestGitHubParseIncomingPushWebhook(t *testing.T) {
 
 func TestGithubParseIncomingPrWebhook(t *testing.T) {
 	tests := []struct {
-		name              string
-		payloadFilename   string
-		payloadSha        string
-		expectedTime      int64
-		expectedEventType vcsutils.WebhookEvent
+		name                    string
+		payloadFilename         string
+		payloadSha              string
+		expectedTime            int64
+		expectedEventType       vcsutils.WebhookEvent
+		expectedPullRequestInfo *WebhookInfoPullRequest
 	}{
 		{
 			name:              "open",
@@ -98,6 +99,32 @@ func TestGithubParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        githubPrOpenSha256,
 			expectedTime:      githubPrOpenExpectedTime,
 			expectedEventType: vcsutils.PrOpened,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         2,
+				Title:      "Update README.md",
+				CompareUrl: "https://github.com/yahavi/hello-world/pull/2/files",
+				Timestamp:  1630666350,
+				Author: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "9d497bd67a395a8063774f200338769ccbcee916",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "c0e22e5ac1277cc24575882e4ca2407f739ae886",
+			},
 		},
 		{
 			name:              "reopen",
@@ -105,6 +132,32 @@ func TestGithubParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        githubPrReopenSha256,
 			expectedTime:      githubPrReopenExpectedTime,
 			expectedEventType: vcsutils.PrOpened,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         2,
+				Title:      "Update+README.md+now",
+				CompareUrl: "https://github.com/yahavi/hello-world/pull/2/files",
+				Timestamp:  1638805321,
+				Author: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "9d497bd67a395a8063774f200338769ccbcee916",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "92e9b0a232117eccf28c2ef4c0021bd33f2fb2a4",
+			},
 		},
 		{
 			name:              "synchronize",
@@ -112,6 +165,32 @@ func TestGithubParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        githubPrSyncSha256,
 			expectedTime:      githubPrSyncExpectedTime,
 			expectedEventType: vcsutils.PrEdited,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         2,
+				Title:      "Update README.md",
+				CompareUrl: "https://github.com/yahavi/hello-world/pull/2/files",
+				Timestamp:  1630666481,
+				Author: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "9d497bd67a395a8063774f200338769ccbcee916",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "92e9b0a232117eccf28c2ef4c0021bd33f2fb2a4",
+			},
 		},
 		{
 			name:              "edit",
@@ -119,6 +198,32 @@ func TestGithubParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        githubPrEditSha256,
 			expectedTime:      githubPrEditExpectedTime,
 			expectedEventType: vcsutils.PrEdited,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         2,
+				Title:      "Update+README.md+now",
+				CompareUrl: "https://github.com/yahavi/hello-world/pull/2/files",
+				Timestamp:  1638802767,
+				Author: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "9d497bd67a395a8063774f200338769ccbcee916",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "92e9b0a232117eccf28c2ef4c0021bd33f2fb2a4",
+			},
 		},
 		{
 			name:              "close",
@@ -126,6 +231,32 @@ func TestGithubParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        githubPrCloseSha256,
 			expectedTime:      githubPrCloseExpectedTime,
 			expectedEventType: vcsutils.PrRejected,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         2,
+				Title:      "Update+README.md+now",
+				CompareUrl: "https://github.com/yahavi/hello-world/pull/2/files",
+				Timestamp:  1638804604,
+				Author: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "9d497bd67a395a8063774f200338769ccbcee916",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "92e9b0a232117eccf28c2ef4c0021bd33f2fb2a4",
+			},
 		},
 		{
 			name:              "merge",
@@ -133,6 +264,32 @@ func TestGithubParseIncomingPrWebhook(t *testing.T) {
 			payloadSha:        githubPrMergeSha256,
 			expectedTime:      githubPrMergeExpectedTime,
 			expectedEventType: vcsutils.PrMerged,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         2,
+				Title:      "Update+README.md+now",
+				CompareUrl: "https://github.com/yahavi/hello-world/pull/2/files",
+				Timestamp:  1638805994,
+				Author: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login:     "yahavi",
+					AvatarUrl: "https://avatars.githubusercontent.com/u/11367982?v=4",
+				},
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "9d497bd67a395a8063774f200338769ccbcee916",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "92e9b0a232117eccf28c2ef4c0021bd33f2fb2a4",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -166,6 +323,7 @@ func TestGithubParseIncomingPrWebhook(t *testing.T) {
 			assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 			assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 			assert.Equal(t, tt.expectedEventType, actual.Event)
+			assert.Equal(t, tt.expectedPullRequestInfo, actual.PullRequest)
 		})
 	}
 }

--- a/vcsutils/webhookparser/gitlab.go
+++ b/vcsutils/webhookparser/gitlab.go
@@ -148,6 +148,29 @@ func (webhook *gitLabWebhookParser) parsePrEvents(event *gitlab.MergeEvent) (*We
 		TargetBranch:            event.ObjectAttributes.TargetBranch,
 		Timestamp:               eventTime.UTC().Unix(),
 		Event:                   webhookEvent,
+		PullRequest: &WebhookInfoPullRequest{
+			ID:         event.ObjectAttributes.IID,
+			Title:      event.ObjectAttributes.Title,
+			CompareUrl: event.ObjectAttributes.URL,
+			Timestamp:  eventTime.Unix(),
+			Author: WebHookInfoUser{
+				Login:       event.User.Username,
+				DisplayName: event.User.Name,
+				Email:       event.User.Email,
+				AvatarUrl:   event.User.AvatarURL,
+			},
+			TriggeredBy: WebHookInfoUser{
+				Login: event.User.Username,
+				Email: event.ObjectAttributes.LastCommit.Author.Email,
+			},
+			SkipDecryption:   true,
+			TargetRepository: webhook.parseRepoDetails(event.ObjectAttributes.Target.PathWithNamespace),
+			TargetBranch:     event.ObjectAttributes.TargetBranch,
+			TargetHash:       "",
+			SourceRepository: webhook.parseRepoDetails(event.ObjectAttributes.Source.PathWithNamespace),
+			SourceBranch:     event.ObjectAttributes.SourceBranch,
+			SourceHash:       event.ObjectAttributes.LastCommit.ID,
+		},
 	}, nil
 }
 

--- a/vcsutils/webhookparser/gitlab_test.go
+++ b/vcsutils/webhookparser/gitlab_test.go
@@ -70,40 +70,186 @@ func TestGitLabParseIncomingPushWebhook(t *testing.T) {
 
 func TestGitLabParseIncomingPrWebhook(t *testing.T) {
 	tests := []struct {
-		name              string
-		payloadFilename   string
-		expectedTime      int64
-		expectedEventType vcsutils.WebhookEvent
+		name                    string
+		payloadFilename         string
+		expectedTime            int64
+		expectedEventType       vcsutils.WebhookEvent
+		expectedPullRequestInfo *WebhookInfoPullRequest
 	}{
 		{
 			name:              "open",
 			payloadFilename:   "propenpayload.json",
 			expectedTime:      gitlabPrOpenExpectedTime,
 			expectedEventType: vcsutils.PrOpened,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         1,
+				Title:      "Update README.md",
+				CompareUrl: "https://gitlab.com/yahavi/hello-world/-/merge_requests/1",
+				Timestamp:  1631202047,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					Email:       "yahavitz@gmail.com",
+					AvatarUrl:   "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?s=80&d=identicon",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+					Email: "yahavitz@gmail.com",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "72108853aa0eac9d1b72fe34710aeed256d193d5",
+			},
 		},
 		{
 			name:              "reopen",
 			payloadFilename:   "prreopenpayload.json",
 			expectedTime:      gitlabPrReopenExpectedTime,
 			expectedEventType: vcsutils.PrOpened,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         1,
+				Title:      "Update README.md",
+				CompareUrl: "https://gitlab.com/yahavi/hello-world/-/merge_requests/1",
+				Timestamp:  1638865856,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					Email:       "yahavitz@gmail.com",
+					AvatarUrl:   "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?s=80&d=identicon",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+					Email: "yahavitz@gmail.com",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "3fcd302505fb3df664143df4ddcb6cfc50ff2ea8",
+			},
 		},
 		{
 			name:              "update",
 			payloadFilename:   "prupdatepayload.json",
 			expectedTime:      gitlabPrUpdateExpectedTime,
 			expectedEventType: vcsutils.PrEdited,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         1,
+				Title:      "Update README.md",
+				CompareUrl: "https://gitlab.com/yahavi/hello-world/-/merge_requests/1",
+				Timestamp:  1631202266,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					Email:       "yahavitz@gmail.com",
+					AvatarUrl:   "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?s=80&d=identicon",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+					Email: "yahavitz@gmail.com",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "3fcd302505fb3df664143df4ddcb6cfc50ff2ea8",
+			},
 		},
 		{
 			name:              "close",
 			payloadFilename:   "prclosepayload.json",
 			expectedTime:      gitlabPrCloseExpectedTime,
 			expectedEventType: vcsutils.PrRejected,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         1,
+				Title:      "Update README.md",
+				CompareUrl: "https://gitlab.com/yahavi/hello-world/-/merge_requests/1",
+				Timestamp:  1638864453,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					Email:       "yahavitz@gmail.com",
+					AvatarUrl:   "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?s=80&d=identicon",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+					Email: "yahavitz@gmail.com",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "3fcd302505fb3df664143df4ddcb6cfc50ff2ea8",
+			},
 		},
 		{
 			name:              "merge",
 			payloadFilename:   "prmergepayload.json",
 			expectedTime:      gitlabPrMergeExpectedTime,
 			expectedEventType: vcsutils.PrMerged,
+			expectedPullRequestInfo: &WebhookInfoPullRequest{
+				ID:         1,
+				Title:      "Update README.md",
+				CompareUrl: "https://gitlab.com/yahavi/hello-world/-/merge_requests/1",
+				Timestamp:  1638866119,
+				Author: WebHookInfoUser{
+					Login:       "yahavi",
+					DisplayName: "Yahav Itzhak",
+					Email:       "yahavitz@gmail.com",
+					AvatarUrl:   "https://secure.gravatar.com/avatar/9680da1674e22a1de17acb19bb233ebf?s=80&d=identicon",
+				},
+				TriggeredBy: WebHookInfoUser{
+					Login: "yahavi",
+					Email: "yahavitz@gmail.com",
+				},
+				SkipDecryption: true,
+				TargetRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				TargetBranch: "main",
+				TargetHash:   "",
+				SourceRepository: WebHookInfoRepoDetails{
+					Name:  "hello-world",
+					Owner: "yahavi",
+				},
+				SourceBranch: "dev",
+				SourceHash:   "3fcd302505fb3df664143df4ddcb6cfc50ff2ea8",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -136,6 +282,7 @@ func TestGitLabParseIncomingPrWebhook(t *testing.T) {
 			assert.Equal(t, expectedOwner, actual.SourceRepositoryDetails.Owner)
 			assert.Equal(t, expectedSourceBranch, actual.SourceBranch)
 			assert.Equal(t, tt.expectedEventType, actual.Event)
+			assert.Equal(t, tt.expectedPullRequestInfo, actual.PullRequest)
 		})
 	}
 }

--- a/vcsutils/webhookparser/webhookparser.go
+++ b/vcsutils/webhookparser/webhookparser.go
@@ -45,6 +45,38 @@ type WebhookInfo struct {
 	Author WebHookInfoUser `json:"author,omitempty"`
 	// CompareUrl is HTML URL to see git comparison between commits (Push event only)
 	CompareUrl string `json:"compare_url,omitempty"`
+	// PullRequest encapsulates information of the pull request.
+	PullRequest *WebhookInfoPullRequest `json:"pull_request,omitempty"`
+}
+
+// WebhookInfoPullRequest contains information about a pull request event received via a webhook.
+type WebhookInfoPullRequest struct {
+	// ID is a unique identifier of the pull request.
+	ID int `json:"id,omitempty"`
+	// Title is a title(name) of the pull request.
+	Title string `json:"title,omitempty"`
+	// CompareUrl is a hyperlink to the pull request.
+	CompareUrl string `json:"url,omitempty"`
+	// Timestamp of the last update (Unix timestamp).
+	Timestamp int64 `json:"timestamp,omitempty"`
+	// Author is an info about pull request author.
+	Author WebHookInfoUser `json:"author,omitempty"`
+	// TriggeredBy
+	TriggeredBy WebHookInfoUser `json:"triggered_by,omitempty"`
+	// SkipDecryption
+	SkipDecryption bool `json:"skip_decryption,omitempty"`
+	// TargetRepository contains details about target repository (destination of the changes).
+	TargetRepository WebHookInfoRepoDetails `json:"target_repository,omitempty"`
+	// TargetBranch is a name of the branch of the TargetRepository.
+	TargetBranch string `json:"target_branch,omitempty"`
+	// TargetHash is a commit SHA of the target branch.
+	TargetHash string `json:"target_hash,omitempty"`
+	// SourceRepository contains details about source repository.
+	SourceRepository WebHookInfoRepoDetails `json:"source_repository,omitempty"`
+	// SourceBranch is a name of the branch of the SourceRepository.
+	SourceBranch string `json:"source_branch,omitempty"`
+	// SourceHash is a commit SHA of the source branch.
+	SourceHash string `json:"source_hash,omitempty"`
 }
 
 // WebHookInfoRepoDetails represents repository info of an incoming webhook


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
The change extends `WebhookInfo` with additional information about Pull request. 
The new field `PullRequest` encapsulates information about pull request, like source and destination, title, etc...
It has fields that duplicate existing one, but it is done intentionally as the current structure is hard to understand and maintain. The old fields will be removed eventually.
The change is needed for https://jfrog-int.atlassian.net/browse/INTG-386.

