### PR TITLE
Fix Bitbucket GetCommitStatus date parsing

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -399,7 +399,7 @@ func (client *AzureReposClient) GetCommitStatuses(ctx context.Context, owner, re
 	results := make([]CommitStatusInfo, 0)
 	for _, singleStatus := range *resGitStatus {
 		results = append(results, CommitStatusInfo{
-			State:         CommitStatusAsStringToStatus(string(*singleStatus.State)),
+			State:         commitStatusAsStringToStatus(string(*singleStatus.State)),
 			Description:   *singleStatus.Description,
 			DetailsUrl:    *singleStatus.TargetUrl,
 			Creator:       *singleStatus.CreatedBy.DisplayName,

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -227,7 +227,7 @@ func (client *BitbucketCloudClient) GetCommitStatuses(ctx context.Context, owner
 	if err != nil {
 		return nil, err
 	}
-	results, err := bitbucketParseCommitStatuses(rawStatuses)
+	results, err := bitbucketParseCommitStatuses(rawStatuses, vcsutils.BitbucketCloud)
 	if err != nil {
 		return nil, err
 	}

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -2,15 +2,29 @@ package vcsclient
 
 import (
 	"errors"
+	"fmt"
+	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/mitchellh/mapstructure"
 	"time"
 )
 
-var errLabelsNotSupported = errors.New("labels are not supported on Bitbucket")
-var errBitbucketCodeScanningNotSupported = errors.New("code scanning is not supported on Bitbucket")
+var (
+	errLabelsNotSupported                          = errors.New("labels are not supported on Bitbucket")
+	errBitbucketCodeScanningNotSupported           = errors.New("code scanning is not supported on Bitbucket")
+	errBitbucketDownloadFileFromRepoNotSupported   = errors.New("download file from repo is currently not supported on Bitbucket")
+	errBitbucketGetRepoEnvironmentInfoNotSupported = errors.New("get repository environment info is currently not supported on Bitbucket")
+)
 
-var errBitbucketDownloadFileFromRepoNotSupported = errors.New("download file from repo is currently not supported on Bitbucket")
-var errBitbucketGetRepoEnvironmentInfoNotSupported = errors.New("get repository environment info is currently not supported on Bitbucket")
+type BitbucketCommitInfo struct {
+	Title       string  `mapstructure:"key"`
+	Url         string  `mapstructure:"url"`
+	State       string  `mapstructure:"state"`
+	Creator     string  `mapstructure:"name"`
+	Description string  `mapstructure:"description"`
+	CreatedOn   string  `mapstructure:"created_on"`
+	UpdatedOn   string  `mapstructure:"updated_on"`
+	DateAdded   float64 `mapstructure:"DateAdded"`
+}
 
 func getBitbucketCommitState(commitState CommitStatus) string {
 	switch commitState {
@@ -25,41 +39,72 @@ func getBitbucketCommitState(commitState CommitStatus) string {
 }
 
 // bitbucketParseCommitStatuses parse raw response into CommitStatusInfo slice
-// The response is the same for BitBucket cloud and server
-func bitbucketParseCommitStatuses(rawStatuses interface{}) ([]CommitStatusInfo, error) {
-	results := make([]CommitStatusInfo, 0)
+func bitbucketParseCommitStatuses(rawStatuses interface{}, provider vcsutils.VcsProvider) ([]CommitStatusInfo, error) {
 	statuses := struct {
-		Statuses []struct {
-			Title         string `mapstructure:"key"`
-			Url           string `mapstructure:"url"`
-			State         string `mapstructure:"state"`
-			Description   string `mapstructure:"description"`
-			Creator       string `mapstructure:"name"`
-			LastUpdatedAt string `mapstructure:"updated_on"`
-			CreatedAt     string `mapstructure:"created_at"`
-		} `mapstructure:"values"`
+		Statuses []BitbucketCommitInfo `mapstructure:"values"`
 	}{}
-	err := mapstructure.Decode(rawStatuses, &statuses)
-	if err != nil {
+	if err := mapstructure.Decode(rawStatuses, &statuses); err != nil {
 		return nil, err
 	}
+
+	var results []CommitStatusInfo
 	for _, commitStatus := range statuses.Statuses {
-		lastUpdatedAt, err := time.Parse(time.RFC3339, commitStatus.LastUpdatedAt)
+		commitInfo, err := getCommitStatusInfoByBitbucketProvider(&commitStatus, provider)
 		if err != nil {
 			return nil, err
 		}
-		createdAt, err := time.Parse(time.RFC3339, commitStatus.LastUpdatedAt)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, CommitStatusInfo{
-			State:         CommitStatusAsStringToStatus(commitStatus.State),
-			Description:   commitStatus.Description,
-			DetailsUrl:    commitStatus.Url,
-			Creator:       commitStatus.Creator,
-			LastUpdatedAt: lastUpdatedAt,
-			CreatedAt:     createdAt,
-		})
+		results = append(results, commitInfo)
 	}
-	return results, err
+	return results, nil
+}
+
+func getCommitStatusInfoByBitbucketProvider(commitStatus *BitbucketCommitInfo, provider vcsutils.VcsProvider) (result CommitStatusInfo, err error) {
+	switch provider {
+	case vcsutils.BitbucketServer:
+		return getBitbucketServerCommitStatusInfo(commitStatus), nil
+	default:
+		return getBitbucketCloudCommitStatusInfo(commitStatus)
+	}
+}
+
+func getBitbucketServerCommitStatusInfo(commitStatus *BitbucketCommitInfo) CommitStatusInfo {
+	// 1. Divide the Unix millisecond timestamp by 1000 to get the Unix time in seconds
+	timeInSec := int64(commitStatus.DateAdded) / int64(time.Microsecond)
+	// 2. Calculate the nanoseconds value by subtracting the seconds value multiplied by 1000 from the original Unix millisecond timestamp
+	//    Finally, multiply the result by 1000000 to get the nanoseconds value
+	timeInNanoSec := (int64(commitStatus.DateAdded) - (timeInSec * int64(time.Microsecond))) * int64(time.Millisecond)
+	return CommitStatusInfo{
+		State:       commitStatusAsStringToStatus(commitStatus.State),
+		Description: commitStatus.Description,
+		DetailsUrl:  commitStatus.Url,
+		Creator:     commitStatus.Title,
+		CreatedAt:   time.Unix(timeInSec, timeInNanoSec).UTC(),
+	}
+}
+
+func getBitbucketCloudCommitStatusInfo(commitStatus *BitbucketCommitInfo) (CommitStatusInfo, error) {
+	var createdOn, updatedOn time.Time
+	var err error
+
+	if commitStatus.CreatedOn != "" {
+		createdOn, err = time.Parse(time.RFC3339, commitStatus.CreatedOn)
+		if err != nil {
+			return CommitStatusInfo{}, fmt.Errorf("error parsing commit status created_on date: %v", err)
+		}
+	}
+	if commitStatus.UpdatedOn != "" {
+		updatedOn, err = time.Parse(time.RFC3339, commitStatus.UpdatedOn)
+		if err != nil {
+			return CommitStatusInfo{}, fmt.Errorf("error parsing commit status updated_on date: %v", err)
+		}
+	}
+
+	return CommitStatusInfo{
+		State:         commitStatusAsStringToStatus(commitStatus.State),
+		Description:   commitStatus.Description,
+		DetailsUrl:    commitStatus.Url,
+		Creator:       commitStatus.Creator,
+		CreatedAt:     createdOn,
+		LastUpdatedAt: updatedOn,
+	}, nil
 }

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -48,8 +48,8 @@ func bitbucketParseCommitStatuses(rawStatuses interface{}, provider vcsutils.Vcs
 	}
 
 	var results []CommitStatusInfo
-	for _, commitStatus := range statuses.Statuses {
-		commitInfo, err := getCommitStatusInfoByBitbucketProvider(&commitStatus, provider)
+	for i := range statuses.Statuses {
+		commitInfo, err := getCommitStatusInfoByBitbucketProvider(&statuses.Statuses[i], provider)
 		if err != nil {
 			return nil, err
 		}

--- a/vcsclient/bitbucketcommon_test.go
+++ b/vcsclient/bitbucketcommon_test.go
@@ -1,7 +1,10 @@
 package vcsclient
 
 import (
+	"github.com/jfrog/froggit-go/vcsutils"
+	"github.com/stretchr/testify/require"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -12,4 +15,93 @@ func TestBitbucketClient_getBitbucketCommitState(t *testing.T) {
 	assert.Equal(t, "FAILED", getBitbucketCommitState(Error))
 	assert.Equal(t, "INPROGRESS", getBitbucketCommitState(InProgress))
 	assert.Equal(t, "", getBitbucketCommitState(5))
+}
+
+func TestBitbucketParseCommitStatuses(t *testing.T) {
+	rawStatuses := map[string]interface{}{
+		"values": []BitbucketCommitInfo{
+			{
+				State:       "SUCCESSFUL",
+				Description: "Build successful",
+				Url:         "http://example.com/build/1234",
+				Title:       "jenkins",
+				DateAdded:   1619189054828,
+			},
+			{
+				State:       "FAILED",
+				Description: "Build failed",
+				Url:         "http://example.com/build/5678",
+				Title:       "jenkins",
+				DateAdded:   1619189055832,
+			},
+		},
+	}
+
+	provider := vcsutils.BitbucketServer
+	expectedStatuses := []CommitStatusInfo{
+		{
+			State:       Pass,
+			Description: "Build successful",
+			DetailsUrl:  "http://example.com/build/1234",
+			Creator:     "jenkins",
+			CreatedAt:   time.Unix(1619189054, 828000000).UTC(),
+		},
+		{
+			State:       Fail,
+			Description: "Build failed",
+			DetailsUrl:  "http://example.com/build/5678",
+			Creator:     "jenkins",
+			CreatedAt:   time.Unix(1619189055, 832000000).UTC(),
+		},
+	}
+
+	statuses, err := bitbucketParseCommitStatuses(rawStatuses, provider)
+	require.NoError(t, err)
+	assert.Equal(t, expectedStatuses, statuses)
+}
+
+func TestGetCommitStatusInfoByBitbucketProvider_BitbucketServer(t *testing.T) {
+	commitStatus := &BitbucketCommitInfo{
+		State:       "SUCCESSFUL",
+		Description: "Build successful",
+		Url:         "http://example.com/build/1234",
+		Title:       "jenkins",
+		DateAdded:   1619189054828,
+	}
+
+	expectedStatus := CommitStatusInfo{
+		State:       Pass,
+		Description: "Build successful",
+		DetailsUrl:  "http://example.com/build/1234",
+		Creator:     "jenkins",
+		CreatedAt:   time.Unix(1619189054, 828000000).UTC(),
+	}
+
+	status, err := getCommitStatusInfoByBitbucketProvider(commitStatus, vcsutils.BitbucketServer)
+	require.NoError(t, err)
+	assert.Equal(t, expectedStatus, status)
+}
+
+func TestGetCommitStatusInfoByBitbucketProvider_BitbucketCloud(t *testing.T) {
+	commitStatus := &BitbucketCommitInfo{
+		State:       "success",
+		Description: "Test commit",
+		Url:         "https://example.com/commit",
+		Creator:     "John Doe",
+		CreatedOn:   "2022-01-01T12:34:56.789Z",
+		UpdatedOn:   "2022-01-02T23:45:01.234Z",
+	}
+
+	expectedResult := CommitStatusInfo{
+		State:         Pass,
+		Description:   "Test commit",
+		DetailsUrl:    "https://example.com/commit",
+		Creator:       "John Doe",
+		CreatedAt:     time.Date(2022, 1, 1, 12, 34, 56, 789000000, time.UTC),
+		LastUpdatedAt: time.Date(2022, 1, 2, 23, 45, 1, 234000000, time.UTC),
+	}
+
+	result, err := getCommitStatusInfoByBitbucketProvider(commitStatus, vcsutils.BitbucketCloud)
+	require.NoError(t, err)
+	require.Equal(t, expectedResult, result)
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -266,7 +266,7 @@ func (client *BitbucketServerClient) GetCommitStatuses(ctx context.Context, owne
 	if err != nil {
 		return nil, err
 	}
-	return bitbucketParseCommitStatuses(response.Values)
+	return bitbucketParseCommitStatuses(response.Values, vcsutils.BitbucketServer)
 }
 
 // DownloadRepository on Bitbucket server
@@ -493,7 +493,7 @@ func (client *BitbucketServerClient) GetRepositoryInfo(ctx context.Context, owne
 }
 
 // GetCommitBySha on Bitbucket server
-func (client BitbucketServerClient) GetCommitBySha(ctx context.Context, owner, repository, sha string) (CommitInfo, error) {
+func (client *BitbucketServerClient) GetCommitBySha(ctx context.Context, owner, repository, sha string) (CommitInfo, error) {
 	err := validateParametersNotBlank(map[string]string{
 		"owner":      owner,
 		"repository": repository,
@@ -521,7 +521,7 @@ func (client BitbucketServerClient) GetCommitBySha(ctx context.Context, owner, r
 }
 
 // CreateLabel on Bitbucket server
-func (client BitbucketServerClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
+func (client *BitbucketServerClient) CreateLabel(ctx context.Context, owner, repository string, labelInfo LabelInfo) error {
 	return errLabelsNotSupported
 }
 

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -203,7 +203,7 @@ func (client *GitHubClient) GetCommitStatuses(ctx context.Context, owner, reposi
 	results := make([]CommitStatusInfo, 0)
 	for _, singleStatus := range statuses.Statuses {
 		results = append(results, CommitStatusInfo{
-			State:         CommitStatusAsStringToStatus(*singleStatus.State),
+			State:         commitStatusAsStringToStatus(*singleStatus.State),
 			Description:   singleStatus.GetDescription(),
 			DetailsUrl:    singleStatus.GetTargetURL(),
 			Creator:       singleStatus.GetCreator().GetName(),

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -185,7 +185,7 @@ func (client *GitLabClient) GetCommitStatuses(ctx context.Context, owner, reposi
 	results := make([]CommitStatusInfo, 0)
 	for _, singleStatus := range statuses {
 		results = append(results, CommitStatusInfo{
-			State:         CommitStatusAsStringToStatus(singleStatus.Status),
+			State:         commitStatusAsStringToStatus(singleStatus.Status),
 			Description:   singleStatus.Description,
 			DetailsUrl:    singleStatus.TargetURL,
 			Creator:       singleStatus.Author.Name,

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -313,9 +313,9 @@ func validateParametersNotBlank(paramNameValueMap map[string]string) error {
 	return nil
 }
 
-// CommitStatusAsStringToStatus maps status as string to CommitStatus
+// commitStatusAsStringToStatus maps status as string to CommitStatus
 // Handles all the different statuses for every VCS provider
-func CommitStatusAsStringToStatus(rawStatus string) CommitStatus {
+func commitStatusAsStringToStatus(rawStatus string) CommitStatus {
 	switch strings.ToLower(rawStatus) {
 	case "success", "succeeded", "successful":
 		return Pass


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
Parsing `createdOn` and `updatedOn` values of a commit status failed due to a wrong response parsing. 
The Bitbucket server scheme is as follows:
```
{
    "size": 1,
    "limit": 25,
    "isLastPage": true,
    "values": [
        {
            "state": "SUCCESSFUL",
            "key": "REPO-MASTER",
            "name": "REPO-MASTER-42",
            "url": "https://bamboo.example.com/browse/REPO-MASTER-42",
            "description": "Changes by John Doe",
            "dateAdded": 1442835514204
        }
    ],
    "start": 0
}
```

The Bitbucket Cloud is as follows:
```
...
"created_on": "<string>",
"updated_on": "<string>"
```

In the case of Bitbucket Server, we'll parse the `dateAdded` field, on Bitbucket Cloud we'll parse the `created_on` and `updated_on` fields.