### PR TITLE
Allow to listen for tag webhook events

### DIFF
--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -625,22 +625,22 @@ func getBitbucketCloudWebhookID(r interface{}) (string, error) {
 
 // Get varargs of webhook events and return a slice of Bitbucket cloud webhook events
 func getBitbucketCloudWebhookEvents(webhookEvents ...vcsutils.WebhookEvent) []string {
-	events := make([]string, 0, len(webhookEvents))
+	events := datastructures.MakeSet[string]()
 	for _, event := range webhookEvents {
 		switch event {
 		case vcsutils.PrOpened:
-			events = append(events, "pullrequest:created")
+			events.Add("pullrequest:created")
 		case vcsutils.PrEdited:
-			events = append(events, "pullrequest:updated")
+			events.Add("pullrequest:updated")
 		case vcsutils.PrRejected:
-			events = append(events, "pullrequest:rejected")
+			events.Add("pullrequest:rejected")
 		case vcsutils.PrMerged:
-			events = append(events, "pullrequest:fulfilled")
-		case vcsutils.Push:
-			events = append(events, "repo:push")
+			events.Add("pullrequest:fulfilled")
+		case vcsutils.Push, vcsutils.TagPushed, vcsutils.TagRemoved:
+			events.Add("repo:push")
 		}
 	}
-	return events
+	return events.ToSlice()
 }
 
 // The get repository request returns HTTP link to the repository - extract the link from the response.

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -104,7 +104,7 @@ func TestBitbucketCloud_UpdateWebhook(t *testing.T) {
 	defer cleanUp()
 
 	err = client.UpdateWebhook(ctx, owner, repo1, branch1, "https://httpbin.org/anything", token, id.String(),
-		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrRejected, vcsutils.PrMerged)
+		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrRejected, vcsutils.PrMerged, vcsutils.TagPushed, vcsutils.TagRemoved)
 	assert.NoError(t, err)
 }
 

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -629,7 +629,7 @@ func getBitbucketServerWebhookEvents(webhookEvents ...vcsutils.WebhookEvent) []s
 			events = append(events, "pr:merged")
 		case vcsutils.PrRejected:
 			events = append(events, "pr:declined", "pr:deleted")
-		case vcsutils.Push:
+		case vcsutils.Push, vcsutils.TagPushed, vcsutils.TagRemoved:
 			events = append(events, "repo:refs_changed")
 		}
 	}

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -114,7 +114,7 @@ func TestBitbucketServer_UpdateWebhook(t *testing.T) {
 	defer cleanUp()
 
 	err := client.UpdateWebhook(ctx, owner, repo1, branch1, "https://httpbin.org/anything", token, stringID,
-		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected)
+		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected, vcsutils.TagPushed, vcsutils.TagRemoved)
 	assert.NoError(t, err)
 
 	err = createBadBitbucketServerClient(t).UpdateWebhook(ctx, owner, repo1, branch1, "https://httpbin.org/anything", token, stringID, vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected)

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -660,16 +660,16 @@ func createGitHubHook(token, payloadURL string, webhookEvents ...vcsutils.Webhoo
 
 // Get varargs of webhook events and return a slice of GitHub webhook events
 func getGitHubWebhookEvents(webhookEvents ...vcsutils.WebhookEvent) []string {
-	events := make([]string, 0, len(webhookEvents))
+	events := datastructures.MakeSet[string]()
 	for _, event := range webhookEvents {
 		switch event {
 		case vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected:
-			events = append(events, "pull_request")
-		case vcsutils.Push:
-			events = append(events, "push")
+			events.Add("pull_request")
+		case vcsutils.Push, vcsutils.TagPushed, vcsutils.TagRemoved:
+			events.Add("push")
 		}
 	}
-	return events
+	return events.ToSlice()
 }
 
 func getGitHubRepositoryVisibility(repo *github.Repository) RepositoryVisibility {

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -143,7 +143,7 @@ func TestGitHubClient_UpdateWebhook(t *testing.T) {
 	defer cleanUp()
 
 	err := client.UpdateWebhook(ctx, owner, repo1, branch1, "https://jfrog.com", token, strconv.FormatInt(id, 10),
-		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected)
+		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected, vcsutils.TagPushed, vcsutils.TagRemoved)
 	assert.NoError(t, err)
 
 	err = createBadGitHubClient(t).UpdateWebhook(ctx, owner, repo1, branch1, "https://jfrog.com", token, strconv.FormatInt(id, 10),

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -121,6 +121,7 @@ func (client *GitLabClient) CreateWebhook(ctx context.Context, owner, repository
 		MergeRequestsEvents:    &projectHook.MergeRequestsEvents,
 		PushEvents:             &projectHook.PushEvents,
 		PushEventsBranchFilter: &projectHook.PushEventsBranchFilter,
+		TagPushEvents:          &projectHook.TagPushEvents,
 	}
 	response, _, err := client.glClient.Projects.AddProjectHook(getProjectID(owner, repository), options,
 		gitlab.WithContext(ctx))
@@ -140,6 +141,7 @@ func (client *GitLabClient) UpdateWebhook(ctx context.Context, owner, repository
 		MergeRequestsEvents:    &projectHook.MergeRequestsEvents,
 		PushEvents:             &projectHook.PushEvents,
 		PushEventsBranchFilter: &projectHook.PushEventsBranchFilter,
+		TagPushEvents:          &projectHook.TagPushEvents,
 	}
 	intWebhook, err := strconv.Atoi(webhookID)
 	if err != nil {
@@ -482,6 +484,8 @@ func createProjectHook(branch string, payloadURL string, webhookEvents ...vcsuti
 		case vcsutils.Push:
 			options.PushEvents = true
 			options.PushEventsBranchFilter = branch
+		case vcsutils.TagPushed, vcsutils.TagRemoved:
+			options.TagPushEvents = true
 		}
 	}
 	return options

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -104,7 +104,7 @@ func TestGitLabClient_UpdateWebhook(t *testing.T) {
 	defer cleanUp()
 
 	err := client.UpdateWebhook(ctx, owner, repo1, branch1, "https://jfrog.com", token, strconv.Itoa(id),
-		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected)
+		vcsutils.PrOpened, vcsutils.PrEdited, vcsutils.PrMerged, vcsutils.PrRejected, vcsutils.TagPushed, vcsutils.TagRemoved)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
If vcsutils.TagPushed or vcsutils.TagRemoved event type is provided the newly created webhook will receive tag related events.

- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
