### PR TITLE
Fix Azure DevOps commit statuses functions

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -375,7 +375,7 @@ func (client *AzureReposClient) SetCommitStatus(ctx context.Context, commitStatu
 		},
 		CommitId:     &ref,
 		RepositoryId: &repository,
-		Project:      &repository,
+		Project:      &client.vcsInfo.Project,
 	}
 	_, err = azureReposGitClient.CreateCommitStatus(ctx, commitStatusArgs)
 	return err
@@ -390,7 +390,7 @@ func (client *AzureReposClient) GetCommitStatuses(ctx context.Context, owner, re
 	commitStatusArgs := git.GetStatusesArgs{
 		CommitId:     &ref,
 		RepositoryId: &repository,
-		Project:      &repository,
+		Project:      &client.vcsInfo.Project,
 	}
 	resGitStatus, err := azureReposGitClient.GetStatuses(ctx, commitStatusArgs)
 	if err != nil {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.
---
There was a bug in getting and setting commit statuses in azure repos.
There was a mismatch between the project name and the repo name.

