### PR TITLE
Fix GitHub cloud remote URLs

### DIFF
--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -19,6 +19,11 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const (
+	GitHubCloudApiEndpoint = "https://api.github.com"
+	GitHubCloneUrl         = "https://github.com"
+)
+
 // GitHubClient API version 3
 type GitHubClient struct {
 	vcsInfo VcsInfo
@@ -246,7 +251,7 @@ func (client *GitHubClient) DownloadRepository(ctx context.Context, owner, repos
 	}
 
 	client.logger.Info(successfulRepoExtraction)
-	return vcsutils.CreateDotGitFolderWithRemote(localPath, vcsutils.RemoteName, vcsutils.GetGenericGitRemoteUrl(client.vcsInfo.APIEndpoint, owner, repository))
+	return vcsutils.CreateDotGitFolderWithRemote(localPath, vcsutils.RemoteName, getGitHubGitRemoteUrl(client, owner, repository))
 }
 
 // CreatePullRequest on GitHub
@@ -749,6 +754,15 @@ func packScanningResult(data string) (string, error) {
 	}
 
 	return compressedScan, err
+}
+
+func getGitHubGitRemoteUrl(client *GitHubClient, owner, repo string) string {
+	// Remotes URLs are different from the REST Api endpoint
+	// In case of on-perm, the URLs are the same.
+	if client.vcsInfo.APIEndpoint == GitHubCloudApiEndpoint {
+		client.vcsInfo.APIEndpoint = GitHubCloneUrl
+	}
+	return fmt.Sprintf("%s/%s/%s.git", strings.TrimSuffix(client.vcsInfo.APIEndpoint, "/"), owner, repo)
 }
 
 type repositoryEnvironmentReviewer struct {

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -757,12 +757,10 @@ func packScanningResult(data string) (string, error) {
 }
 
 func getGitHubGitRemoteUrl(client *GitHubClient, owner, repo string) string {
-	// Remotes URLs are different from the REST Api endpoint
-	// In case of on-perm, the URLs are the same.
 	if client.vcsInfo.APIEndpoint == GitHubCloudApiEndpoint {
-		client.vcsInfo.APIEndpoint = GitHubCloneUrl
+		return fmt.Sprintf("%s/%s/%s.git", GitHubCloneUrl, owner, repo)
 	}
-	return fmt.Sprintf("%s/%s/%s.git", strings.TrimSuffix(client.vcsInfo.APIEndpoint, "/"), owner, repo)
+	return fmt.Sprintf("%s/%s/%s.git", client.vcsInfo.APIEndpoint, owner, repo)
 }
 
 type repositoryEnvironmentReviewer struct {

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -754,6 +754,38 @@ func createGitHubWithBodyHandler(t *testing.T, expectedURI string, response []by
 		assert.NoError(t, err)
 	}
 }
+func TestGitHubClient_GetGenericGitRemoteUrl(t *testing.T) {
+	testCases := []struct {
+		name           string
+		apiEndpoint    string
+		owner          string
+		repo           string
+		expectedResult string
+	}{
+		{
+			name:           "GitHub Cloud",
+			apiEndpoint:    "https://api.github.com",
+			owner:          "my-org",
+			repo:           "my-repo",
+			expectedResult: "https://github.com/my-org/my-repo.git",
+		},
+		{
+			name:           "GitHub On-Premises",
+			apiEndpoint:    "https://github.example.com/api/v3",
+			owner:          "my-org",
+			repo:           "my-repo",
+			expectedResult: "https://github.example.com/api/v3/my-org/my-repo.git",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info := VcsInfo{APIEndpoint: tc.apiEndpoint}
+			client, err := NewGitHubClient(info, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedResult, getGitHubGitRemoteUrl(client, tc.owner, tc.repo))
+		})
+	}
+}
 
 func createGitHubWithPaginationHandler(t *testing.T, _ string, response []byte, _ []byte, expectedStatusCode int, expectedHttpMethod string) http.HandlerFunc {
 	var repos []github.Repository

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -732,29 +732,7 @@ func TestGitHubClient_TestGetCommitStatus(t *testing.T) {
 	})
 }
 
-func createBadGitHubClient(t *testing.T) VcsClient {
-	client, err := NewClientBuilder(vcsutils.GitHub).ApiEndpoint("https://bad^endpoint").Build()
-	require.NoError(t, err)
-	return client
-}
-
-func createGitHubWithBodyHandler(t *testing.T, expectedURI string, response []byte, expectedRequestBody []byte,
-	expectedStatusCode int, expectedHttpMethod string) http.HandlerFunc {
-	return func(writer http.ResponseWriter, request *http.Request) {
-		assert.Equal(t, expectedHttpMethod, request.Method)
-		assert.Equal(t, expectedURI, request.RequestURI)
-		assert.Equal(t, "Bearer "+token, request.Header.Get("Authorization"))
-
-		b, err := io.ReadAll(request.Body)
-		require.NoError(t, err)
-		assert.Equal(t, expectedRequestBody, b)
-
-		writer.WriteHeader(expectedStatusCode)
-		_, err = writer.Write(response)
-		assert.NoError(t, err)
-	}
-}
-func TestGitHubClient_GetGenericGitRemoteUrl(t *testing.T) {
+func TestGitHubClient_getGitHubGitRemoteUrl(t *testing.T) {
 	testCases := []struct {
 		name           string
 		apiEndpoint    string
@@ -784,6 +762,29 @@ func TestGitHubClient_GetGenericGitRemoteUrl(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedResult, getGitHubGitRemoteUrl(client, tc.owner, tc.repo))
 		})
+	}
+}
+
+func createBadGitHubClient(t *testing.T) VcsClient {
+	client, err := NewClientBuilder(vcsutils.GitHub).ApiEndpoint("https://bad^endpoint").Build()
+	require.NoError(t, err)
+	return client
+}
+
+func createGitHubWithBodyHandler(t *testing.T, expectedURI string, response []byte, expectedRequestBody []byte,
+	expectedStatusCode int, expectedHttpMethod string) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		assert.Equal(t, expectedHttpMethod, request.Method)
+		assert.Equal(t, expectedURI, request.RequestURI)
+		assert.Equal(t, "Bearer "+token, request.Header.Get("Authorization"))
+
+		b, err := io.ReadAll(request.Body)
+		require.NoError(t, err)
+		assert.Equal(t, expectedRequestBody, b)
+
+		writer.WriteHeader(expectedStatusCode)
+		_, err = writer.Write(response)
+		assert.NoError(t, err)
 	}
 }
 

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -226,20 +226,6 @@ func TestGetGenericGitRemoteUrl(t *testing.T) {
 			expectedResult: "https://bitbucket.example.com/scm/my-org/my-repo.git",
 		},
 		{
-			name:           "GitHub Cloud",
-			apiEndpoint:    "https://api.github.com",
-			owner:          "my-org",
-			repo:           "my-repo",
-			expectedResult: "https://api.github.com/my-org/my-repo.git",
-		},
-		{
-			name:           "GitHub On-Premises",
-			apiEndpoint:    "https://github.example.com/api/v3",
-			owner:          "my-org",
-			repo:           "my-repo",
-			expectedResult: "https://github.example.com/api/v3/my-org/my-repo.git",
-		},
-		{
 			name:           "GitLab",
 			apiEndpoint:    "https://gitlab.com/",
 			owner:          "my-org",
@@ -254,7 +240,6 @@ func TestGetGenericGitRemoteUrl(t *testing.T) {
 			expectedResult: "https://gitlab.example.com/api/v4/my-org/my-repo.git",
 		},
 	}
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, GetGenericGitRemoteUrl(tc.apiEndpoint, tc.owner, tc.repo))

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -240,6 +240,7 @@ func TestGetGenericGitRemoteUrl(t *testing.T) {
 			expectedResult: "https://gitlab.example.com/api/v4/my-org/my-repo.git",
 		},
 	}
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, GetGenericGitRemoteUrl(tc.apiEndpoint, tc.owner, tc.repo))


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---

**Bug description:**
When downloading a repo from GitHub cloud, the ApiEndpoint was set to `api.github.com`
and it was used to set the remote urls as well as `https://api.github.com/my-org/my-repo.git`
this is wrong as the remote url should be the GitHub host url which is `https://github.com/my-org/my-repo.git`

Bitbucket server & cloud is working correctly.
GitLab on perm & cloud is also working correctly.
