### PR TITLE
Fix wrong status code in Bitbucket Server DownloadRepository API

### DIFF
--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -580,11 +580,16 @@ func (client *BitbucketServerClient) DownloadFileFromRepo(ctx context.Context, o
 	if err != nil {
 		return nil, 0, err
 	}
+
+	var statusCode int
 	resp, err := bitbucketClient.GetContent_11(owner, repository, path, map[string]interface{}{"at": branch})
-	if err != nil {
-		return nil, 0, err
+	if resp != nil {
+		statusCode = resp.StatusCode
 	}
-	return resp.Payload, resp.StatusCode, err
+	if err != nil {
+		return nil, statusCode, err
+	}
+	return resp.Payload, statusCode, err
 }
 
 func createPaginationOptions(nextPageStart int) map[string]interface{} {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
