### PR TITLE
Support DownloadFileFromRepo for Azure Repos

### DIFF
--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -320,10 +320,21 @@ func TestAzureReposClient_UploadCodeScanning(t *testing.T) {
 
 func TestAzureReposClient_DownloadFileFromRepo(t *testing.T) {
 	ctx := context.Background()
-	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, "", "unsupportedTest", createAzureReposHandler)
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, "", "badTest", createAzureReposHandler)
 	defer cleanUp()
 	_, _, err := client.DownloadFileFromRepo(ctx, owner, repo1, "", "")
 	assert.Error(t, err)
+	client, cleanUp = createServerAndClient(t, vcsutils.AzureRepos, true, []byte("good"), "/_apis/ResourceAreas/DownloadFileFromRepo?includeContent=true&path=file.txt&versionDescriptor.version=&versionDescriptor.versionType=branch", createAzureReposHandler)
+	defer cleanUp()
+	content, statusCode, err := client.DownloadFileFromRepo(ctx, owner, repo1, "", "file.txt")
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, "good", string(content))
+	client, cleanUp = createServerAndClient(t, vcsutils.AzureRepos, true, "", "bad^endpoint", createAzureReposHandler)
+	defer cleanUp()
+	_, statusCode, err = client.DownloadFileFromRepo(ctx, owner, repo1, "", "file.txt")
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, statusCode)
 }
 
 func TestAzureReposClient_CreateWebhook(t *testing.T) {

--- a/vcsclient/testdata/azurerepos/resourcesResponse.json
+++ b/vcsclient/testdata/azurerepos/resourcesResponse.json
@@ -89,6 +89,16 @@
       "minVersion": "3.2",
       "maxVersion": "7.1",
       "releasedVersion": "0.0"
+    },
+    {
+      "id": "fb93c0db-47ed-4a31-8c20-47552878fb44",
+      "area": "Location",
+      "resourceName": "ResourceAreas",
+      "routeTemplate": "_apis/{resource}/DownloadFileFromRepo",
+      "resourceVersion": 1,
+      "minVersion": "3.2",
+      "maxVersion": "7.1",
+      "releasedVersion": "0.0"
     }
   ],
   "count": 2


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
