### PR TITLE
Fix GitLab pull request state parameter

### DIFF
--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -237,7 +237,7 @@ func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, reposi
 
 // ListOpenPullRequests on GitLab
 func (client *GitLabClient) ListOpenPullRequests(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
-	openState := "open"
+	openState := "opened"
 	allScope := "all"
 	options := &gitlab.ListMergeRequestsOptions{
 		State: &openState,

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -208,7 +208,7 @@ func TestGitLabClient_ListOpenPullRequests(t *testing.T) {
 	assert.NoError(t, err)
 
 	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, response,
-		"/api/v4/merge_requests?scope=all&state=open", createGitLabHandler)
+		"/api/v4/merge_requests?scope=all&state=opened", createGitLabHandler)
 	defer cleanUp()
 
 	result, err := client.ListOpenPullRequests(ctx, owner, repo1)

--- a/vcsclient/testdata/gitlab/pull_requests_list_response.json
+++ b/vcsclient/testdata/gitlab/pull_requests_list_response.json
@@ -5,7 +5,7 @@
     "project_id": 3,
     "title": "test1",
     "description": "fixed login page css paddings",
-    "state": "open",
+    "state": "opened",
     "merge_user": {
       "id": 87854,
       "name": "Douwe Maan",


### PR DESCRIPTION
Correct the `state` parameter from `open` which causes gitlab to return the error `{"error":"state does not have a valid value"}` to `opened`.

`opened` matches the [Gitlab API specification](https://docs.gitlab.com/ee/api/merge_requests.html) where the `state` can only be `opened`, `closed`, `locked`, `merged` or `all` 