### PR TITLE
Add the ability to update pull requests metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/go-github/v45 v45.2.0
 	github.com/google/uuid v1.3.0
 	github.com/grokify/mogo v0.40.4
-	github.com/jfrog/gofrog v1.2.5
+	github.com/jfrog/gofrog v1.3.0
 	github.com/ktrysmt/go-bitbucket v0.9.32
 	github.com/microsoft/azure-devops-go-api/azuredevops v1.0.0-b5
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jfrog/froggit-go
 go 1.20
 
 require (
-	github.com/gfleury/go-bitbucket-v1 v0.0.0-20220418082332-711d7d5e805f
+	github.com/gfleury/go-bitbucket-v1 v0.0.0-20230626192437-8d7be5866751
 	github.com/go-git/go-git/v5 v5.5.2
 	github.com/google/go-github/v45 v45.2.0
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuW
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
-github.com/cloudflare/circl v1.1.0 h1:bZgT/A+cikZnKIwn7xL2OBj012Bmvho/o6RpRvv3GKY=
 github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cloudflare/circl v1.3.3 h1:fE/Qz0QdIGqeWfnwq0RE0R7MI51s0M2E4Ga9kq5AEMs=
 github.com/cloudflare/circl v1.3.3/go.mod h1:5XYMA4rFBvNIrhs50XuiBJ15vF2pZn4nnUKZrLbUZFA=
@@ -23,8 +22,8 @@ github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FM
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/gfleury/go-bitbucket-v1 v0.0.0-20220418082332-711d7d5e805f h1:xVRGXRHjGaqT9M+mNNQrsoku+p2z/+Ei/b2gs7ZCbZw=
-github.com/gfleury/go-bitbucket-v1 v0.0.0-20220418082332-711d7d5e805f/go.mod h1:LB3osS9X2JMYmTzcCArHHLrndBAfcVLQAvUddfs+ONs=
+github.com/gfleury/go-bitbucket-v1 v0.0.0-20230626192437-8d7be5866751 h1:Ea58sAu8LX/NS7z3aeL+YX/7+FSd9jsxq6Ecpz7QEDM=
+github.com/gfleury/go-bitbucket-v1 v0.0.0-20230626192437-8d7be5866751/go.mod h1:IqOZzks2wlWCIai0esXnZPdPwxF2yOz0HcCYw5I4pCg=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=
 github.com/gliderlabs/ssh v0.3.5/go.mod h1:8XB4KraRrX39qHhT6yxPsHedjA08I/uBVwj4xC+/+z4=
 github.com/go-git/gcfg v1.5.0 h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
@@ -204,6 +203,7 @@ golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuX
 golang.org/x/term v0.0.0-20220722155259-a9ba230a4035/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.2.0/go.mod h1:TVmDHMZPmdnySmBfhjOoOdhjzdE1h4u1VwSiw2l1Nuc=
 golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=
+golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -211,6 +211,7 @@ golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
+golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.1.0 h1:xYY+Bajn2a7VBmTM5GikTmnK8ZuX8YgnQCqZpbBNtmA=
 golang.org/x/time v0.1.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/gofrog v1.2.5 h1:jCgJC0iGQ8bU7jCC+YEFJTNINyngApIrhd8BjZAVRIE=
-github.com/jfrog/gofrog v1.2.5/go.mod h1:o00tSRff6IapTgaCMuX1Cs9MH08Y1JqnsKgRtx91Gc4=
+github.com/jfrog/gofrog v1.3.0 h1:o4zgsBZE4QyDbz2M7D4K6fXPTBJht+8lE87mS9bw7Gk=
+github.com/jfrog/gofrog v1.3.0/go.mod h1:IFMc+V/yf7rA5WZ74CSbXe+Lgf0iApEQLxRZVzKRUR0=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
 github.com/k0kubun/pp v2.3.0+incompatible/go.mod h1:GWse8YhT0p8pT4ir3ZgBbfZild3tgzSScAn6HmfYukg=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -183,6 +183,7 @@ func (client *AzureReposClient) UpdatePullRequest(ctx context.Context, owner, re
 	if err != nil {
 		return err
 	}
+	// If the string is empty,do not add a prefix,as it indicates that the user does not intend to update the target branch.
 	if targetBranchName != "" {
 		targetBranchName = vcsutils.AddBranchPrefix(targetBranchName)
 	}

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -183,7 +183,9 @@ func (client *AzureReposClient) UpdatePullRequest(ctx context.Context, owner, re
 	if err != nil {
 		return err
 	}
-	targetBranchName = vcsutils.AddBranchPrefix(targetBranchName)
+	if targetBranchName != "" {
+		targetBranchName = vcsutils.AddBranchPrefix(targetBranchName)
+	}
 	client.logger.Debug(updatingPullRequest, prId)
 	_, err = azureReposGitClient.UpdatePullRequest(ctx, git.UpdatePullRequestArgs{
 		GitPullRequestToUpdate: &git.GitPullRequest{

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -146,6 +146,9 @@ func TestAzureReposClient_TestUpdatePullRequest(t *testing.T) {
 	err := client.UpdatePullRequest(ctx, owner, repo1, "Hello World", "Hello World", "", pullRequestId, vcsutils.Open)
 	assert.NoError(t, err)
 
+	err = client.UpdatePullRequest(ctx, owner, repo1, "Hello World", "Hello World", "somebranch", pullRequestId, vcsutils.Open)
+	assert.NoError(t, err)
+
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
 	err = badClient.UpdatePullRequest(ctx, "", repo1, "Hello World", "Hello World", "", pullRequestId, vcsutils.Open)

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -138,25 +138,12 @@ func TestAzureRepos_TestCreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestAzureReposClient_UpdatePullRequest(t *testing.T) {
+func TestAzureReposClient_TestUpdatePullRequest(t *testing.T) {
 	ctx := context.Background()
 	pullRequestId := 1
-	desc := "desc"
-	title := "title"
-	targetBranchName := "master"
-	state := vcsutils.Open
-	res := &git.GitPullRequest{
-		Description:   &desc,
-		PullRequestId: &pullRequestId,
-		Status:        azureMapPullRequestState(state),
-		TargetRefName: &targetBranchName,
-		Title:         &title,
-	}
-	jsonRes, err := json.Marshal(res)
-	assert.NoError(t, err)
-	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, false, jsonRes, "updatePullRequest", createAzureReposHandler)
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, []byte("{}"), "", createAzureReposHandler)
 	defer cleanUp()
-	err = client.UpdatePullRequest(ctx, "", repo1, "Hello World", "Hello World", "", pullRequestId, vcsutils.Open)
+	err := client.UpdatePullRequest(ctx, owner, repo1, "Hello World", "Hello World", "", pullRequestId, vcsutils.Open)
 	assert.NoError(t, err)
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -146,7 +146,10 @@ func TestAzureReposClient_TestUpdatePullRequest(t *testing.T) {
 	err := client.UpdatePullRequest(ctx, owner, repo1, "Hello World", "Hello World", "", pullRequestId, vcsutils.Open)
 	assert.NoError(t, err)
 
-	err = client.UpdatePullRequest(ctx, owner, repo1, "Hello World", "Hello World", "somebranch", pullRequestId, vcsutils.Open)
+	err = client.UpdatePullRequest(ctx, owner, repo1, "Hello World", "Hello World", "somebranch", pullRequestId, vcsutils.Closed)
+	assert.NoError(t, err)
+
+	err = client.UpdatePullRequest(ctx, owner, repo1, "Hello World", "Hello World", "somebranch", pullRequestId, "unknownState")
 	assert.NoError(t, err)
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -154,14 +154,14 @@ func TestAzureReposClient_UpdatePullRequest(t *testing.T) {
 	}
 	jsonRes, err := json.Marshal(res)
 	assert.NoError(t, err)
-	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, "updatePullRequest", createAzureReposHandler)
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, false, jsonRes, "updatePullRequest", createAzureReposHandler)
 	defer cleanUp()
-	err = client.UpdatePullRequest(ctx, "", repo1, "Hello World", "Hello World", "", 5, vcsutils.Open)
+	err = client.UpdatePullRequest(ctx, "", repo1, "Hello World", "Hello World", "", pullRequestId, vcsutils.Open)
 	assert.NoError(t, err)
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
-	err = badClient.CreatePullRequest(ctx, "", repo1, branch1, branch2, "Hello World", "Hello World")
+	err = badClient.UpdatePullRequest(ctx, "", repo1, "Hello World", "Hello World", "", pullRequestId, vcsutils.Open)
 	assert.Error(t, err)
 }
 

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -138,6 +138,32 @@ func TestAzureRepos_TestCreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestAzureReposClient_UpdatePullRequest(t *testing.T) {
+	ctx := context.Background()
+	pullRequestId := 1
+	desc := "desc"
+	title := "title"
+	targetBranchName := "master"
+	state := vcsutils.Open
+	res := &git.GitPullRequest{
+		Description:   &desc,
+		PullRequestId: &pullRequestId,
+		Status:        azureMapPullRequestState(state),
+		TargetRefName: &targetBranchName,
+		Title:         &title,
+	}
+	jsonRes, err := json.Marshal(res)
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, "updatePullRequest", createAzureReposHandler)
+	defer cleanUp()
+	err = client.UpdatePullRequest(ctx, "", repo1, "Hello World", "Hello World", "", 5, vcsutils.Open)
+	assert.NoError(t, err)
+
+	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
+	defer cleanUp()
+	err = badClient.CreatePullRequest(ctx, "", repo1, branch1, branch2, "Hello World", "Hello World")
+	assert.Error(t, err)
+}
+
 func TestAzureRepos_TestAddPullRequestComment(t *testing.T) {
 	type AddPullRequestCommentResponse struct {
 		Value git.GitPullRequestCommentThread

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -153,6 +153,7 @@ func TestAzureReposClient_UpdatePullRequest(t *testing.T) {
 		Title:         &title,
 	}
 	jsonRes, err := json.Marshal(res)
+	assert.NoError(t, err)
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, "updatePullRequest", createAzureReposHandler)
 	defer cleanUp()
 	err = client.UpdatePullRequest(ctx, "", repo1, "Hello World", "Hello World", "", 5, vcsutils.Open)

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -293,6 +294,24 @@ func (client *BitbucketCloudClient) CreatePullRequest(ctx context.Context, owner
 		Description:       description,
 	}
 	_, err := bitbucketClient.Repositories.PullRequests.Create(options)
+	return err
+}
+
+// UpdatePullRequest on Bitbucket cloud
+func (client *BitbucketCloudClient) UpdatePullRequest(ctx context.Context, owner, repository, title, body, targetBranchName string, prId int, state vcsutils.PullRequestState) error {
+	bitbucketClient := client.buildBitbucketCloudClient(ctx)
+	client.logger.Debug(creatingPullRequest, title)
+	options := &bitbucket.PullRequestsOptions{
+		Owner:             owner,
+		SourceRepository:  owner + "/" + repository,
+		RepoSlug:          repository,
+		Title:             title,
+		Description:       body,
+		DestinationBranch: targetBranchName,
+		ID:                strconv.Itoa(prId),
+		States:            []string{*vcsutils.MapPullRequestState(&state)},
+	}
+	_, err := bitbucketClient.Repositories.PullRequests.Update(options)
 	return err
 }
 

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -155,6 +155,16 @@ func TestBitbucketCloud_CreatePullRequest(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestBitbucketCloudClient_UpdatePullRequest(t *testing.T) {
+	ctx := context.Background()
+	prId := 3
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketCloud, true, nil, fmt.Sprintf("/repositories/jfrog/repo-1/pullrequests/%v", prId), createBitbucketCloudHandler)
+	defer cleanUp()
+
+	err := client.UpdatePullRequest(ctx, owner, repo1, "PR title", "PR body", "master", prId, vcsutils.Open)
+	assert.NoError(t, err)
+}
+
 func TestBitbucketCloud_ListOpenPullRequests(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud", "pull_requests_list_response.json"))

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -326,6 +326,31 @@ func (client *BitbucketServerClient) CreatePullRequest(ctx context.Context, owne
 	return err
 }
 
+// UpdatePullRequest on bitbucket server
+// Changing targetBranchRef currently not supported.
+func (client *BitbucketServerClient) UpdatePullRequest(ctx context.Context, owner, repository, title, body, targetBranchRef string, prId int, state vcsutils.PullRequestState) (err error) {
+	bitbucketClient, err := client.buildBitbucketClient(ctx)
+	if err != nil {
+		return
+	}
+	apiResponse, err := bitbucketClient.GetPullRequest(owner, repository, prId)
+	if err != nil {
+		return
+	}
+	version := apiResponse.Values["version"]
+	editOptions := bitbucketv1.EditPullRequestOptions{
+		Version:     fmt.Sprintf("%v", version),
+		ID:          int64(prId),
+		State:       *vcsutils.MapPullRequestState(&state),
+		Title:       title,
+		Description: body,
+	}
+	if apiResponse, err := bitbucketClient.UpdatePullRequest(owner, repository, &editOptions); err != nil {
+		return fmt.Errorf("update pull request failed with status %v, error message: %s", apiResponse.StatusCode, apiResponse.Message)
+	}
+	return
+}
+
 // ListOpenPullRequests on Bitbucket server
 func (client *BitbucketServerClient) ListOpenPullRequests(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
 	bitbucketClient, err := client.buildBitbucketClient(ctx)

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -345,10 +345,8 @@ func (client *BitbucketServerClient) UpdatePullRequest(ctx context.Context, owne
 		Title:       title,
 		Description: body,
 	}
-	if apiResponse, err := bitbucketClient.UpdatePullRequest(owner, repository, &editOptions); err != nil {
-		return fmt.Errorf("update pull request failed with status %v, error message: %s", apiResponse.StatusCode, apiResponse.Message)
-	}
-	return
+	_, err = bitbucketClient.UpdatePullRequest(owner, repository, &editOptions)
+	return err
 }
 
 // ListOpenPullRequests on Bitbucket server

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -186,6 +186,19 @@ func TestBitbucketServer_CreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestBitbucketServer_UpdatePullRequest(t *testing.T) {
+	prId := 4
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, nil, fmt.Sprintf("/rest/api/1.0/projects/jfrog/repos/repo-1/pull-requests/%v", prId), createBitbucketServerHandler)
+	defer cleanUp()
+
+	err := client.UpdatePullRequest(ctx, owner, repo1, "PR title", "PR body", "", prId, vcsutils.Open)
+	assert.NoError(t, err)
+
+	err = createBadBitbucketServerClient(t).UpdatePullRequest(ctx, owner, repo1, "PR title", "PR body", "", prId, vcsutils.Open)
+	assert.Error(t, err)
+}
+
 func TestBitbucketServer_AddPullRequestComment(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, nil, "/rest/api/1.0/projects/jfrog/repos/repo-1/pull-requests/1/comments", createBitbucketServerHandler)

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -272,6 +272,23 @@ func (client *GitHubClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
+// UpdatePullRequest on GitHub
+func (client *GitHubClient) UpdatePullRequest(ctx context.Context, owner, repository, title, body, targetBranchName string, id int, state vcsutils.PullRequestState) error {
+	ghClient, err := client.buildGithubClient(ctx)
+	if err != nil {
+		return err
+	}
+	client.logger.Debug(updatingPullRequest, id)
+	pullRequest := &github.PullRequest{
+		Body:  &body,
+		Title: &title,
+		State: vcsutils.MapPullRequestState(&state),
+		Base:  &github.PullRequestBranch{Ref: &targetBranchName},
+	}
+	_, _, err = ghClient.PullRequests.Edit(ctx, owner, repository, id, pullRequest)
+	return err
+}
+
 // ListOpenPullRequests on GitHub
 func (client *GitHubClient) ListOpenPullRequests(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
 	ghClient, err := client.buildGithubClient(ctx)

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -279,11 +279,15 @@ func (client *GitHubClient) UpdatePullRequest(ctx context.Context, owner, reposi
 		return err
 	}
 	client.logger.Debug(updatingPullRequest, id)
+	var baseRef *github.PullRequestBranch
+	if targetBranchName != "" {
+		baseRef = &github.PullRequestBranch{Ref: &targetBranchName}
+	}
 	pullRequest := &github.PullRequest{
 		Body:  &body,
 		Title: &title,
 		State: vcsutils.MapPullRequestState(&state),
-		Base:  &github.PullRequestBranch{Ref: &targetBranchName},
+		Base:  baseRef,
 	}
 	_, _, err = ghClient.PullRequests.Edit(ctx, owner, repository, id, pullRequest)
 	return err

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -262,6 +262,9 @@ func TestGitHubClient_UpdatePullRequest(t *testing.T) {
 	err := client.UpdatePullRequest(ctx, owner, repo1, "title", "body", "", pullRequestId, vcsutils.Open)
 	assert.NoError(t, err)
 
+	err = client.UpdatePullRequest(ctx, owner, repo1, "title", "body", "master", pullRequestId, vcsutils.Open)
+	assert.NoError(t, err)
+
 	err = createBadGitHubClient(t).CreatePullRequest(ctx, owner, repo1, branch1, branch2, "PR title", "PR body")
 	assert.Error(t, err)
 }

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -253,6 +253,19 @@ func TestGitHubClient_CreatePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGitHubClient_UpdatePullRequest(t *testing.T) {
+	pullRequestId := 3
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.PullRequest{}, fmt.Sprintf("/repos/jfrog/repo-1/pulls/%v", pullRequestId), createGitHubHandler)
+	defer cleanUp()
+
+	err := client.UpdatePullRequest(ctx, owner, repo1, "title", "body", "", pullRequestId, vcsutils.Open)
+	assert.NoError(t, err)
+
+	err = createBadGitHubClient(t).CreatePullRequest(ctx, owner, repo1, branch1, branch2, "PR title", "PR body")
+	assert.Error(t, err)
+}
+
 func TestGitHubClient_AddPullRequestComment(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.IssueComment{}, "/repos/jfrog/repo-1/issues/1/comments", createGitHubHandler)

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -235,6 +235,19 @@ func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, reposi
 	return err
 }
 
+// UpdatePullRequest on GitLab
+func (client *GitLabClient) UpdatePullRequest(ctx context.Context, owner, repository, title, body, targetBranchName string, prId int, state vcsutils.PullRequestState) error {
+	options := &gitlab.UpdateMergeRequestOptions{
+		Title:        &title,
+		Description:  &body,
+		TargetBranch: &targetBranchName,
+		StateEvent:   vcsutils.MapPullRequestState(&state),
+	}
+	client.logger.Debug("updating details of merge request ID:", prId)
+	_, _, err := client.glClient.MergeRequests.UpdateMergeRequest(getProjectID(owner, repository), prId, options, gitlab.WithContext(ctx))
+	return err
+}
+
 // ListOpenPullRequests on GitLab
 func (client *GitLabClient) ListOpenPullRequests(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
 	openState := "opened"

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -172,6 +172,16 @@ func TestGitLabClient_CreatePullRequest(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestGitLabClient_UpdatePullRequest(t *testing.T) {
+	ctx := context.Background()
+	prId := 5
+	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, &gitlab.MergeRequest{}, fmt.Sprintf("/api/v4/projects/%s/merge_requests/%v", url.PathEscape(owner+"/"+repo1), prId), createGitLabHandler)
+	defer cleanUp()
+
+	err := client.UpdatePullRequest(ctx, owner, repo1, "PR title", "PR body", "master", prId, vcsutils.Open)
+	assert.NoError(t, err)
+}
+
 func TestGitLabClient_AddPullRequestComment(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, &gitlab.MergeRequest{}, fmt.Sprintf("/api/v4/projects/%s/merge_requests/1/notes", url.PathEscape(owner+"/"+repo1)), createGitLabHandler)

--- a/vcsclient/logger.go
+++ b/vcsclient/logger.go
@@ -4,6 +4,8 @@ const (
 	successfulRepoDownload   = "repository downloaded successfully. Starting with repository extraction..."
 	successfulRepoExtraction = "Extracted repository successfully"
 	creatingPullRequest      = "Creating new pull request:"
+
+	updatingPullRequest      = "Updating details of pull request ID:"
 	fetchingOpenPullRequests = "Fetching open pull requests in"
 	uploadingCodeScanning    = "Uploading code scanning for:"
 )

--- a/vcsclient/testdata/azurerepos/resourcesResponse.json
+++ b/vcsclient/testdata/azurerepos/resourcesResponse.json
@@ -49,15 +49,6 @@
       "minVersion": "3.2",
       "maxVersion": "7.1",
       "releasedVersion": "0.0"
-    }, {
-      "id": "9946fd70-0d40-406e-b686-b4744cbbcc37",
-      "area": "Location",
-      "resourceName": "ResourceAreas",
-      "routeTemplate": "_apis/{resource}/{areaId}/updatePullRequest",
-      "resourceVersion": 1,
-      "minVersion": "3.2",
-      "maxVersion": "7.1",
-      "releasedVersion": "0.0"
     },
     {
       "id": "c2570c3b-5b3f-41b8-98bf-5407bfde8d58",

--- a/vcsclient/testdata/azurerepos/resourcesResponse.json
+++ b/vcsclient/testdata/azurerepos/resourcesResponse.json
@@ -99,6 +99,16 @@
       "minVersion": "3.2",
       "maxVersion": "7.1",
       "releasedVersion": "0.0"
+    },
+    {
+      "id": "9946fd70-0d40-406e-b686-b4744cbbcc37",
+      "area": "Location",
+      "resourceName": "ResourceAreas",
+      "routeTemplate": "_apis/{resource}/{areaId}/updatePullRequest",
+      "resourceVersion": 1,
+      "minVersion": "3.2",
+      "maxVersion": "7.1",
+      "releasedVersion": "0.0"
     }
   ],
   "count": 2

--- a/vcsclient/testdata/azurerepos/resourcesResponse.json
+++ b/vcsclient/testdata/azurerepos/resourcesResponse.json
@@ -49,6 +49,15 @@
       "minVersion": "3.2",
       "maxVersion": "7.1",
       "releasedVersion": "0.0"
+    }, {
+      "id": "9946fd70-0d40-406e-b686-b4744cbbcc37",
+      "area": "Location",
+      "resourceName": "ResourceAreas",
+      "routeTemplate": "_apis/{resource}/{areaId}/updatePullRequest",
+      "resourceVersion": 1,
+      "minVersion": "3.2",
+      "maxVersion": "7.1",
+      "releasedVersion": "0.0"
     },
     {
       "id": "c2570c3b-5b3f-41b8-98bf-5407bfde8d58",
@@ -95,16 +104,6 @@
       "area": "Location",
       "resourceName": "ResourceAreas",
       "routeTemplate": "_apis/{resource}/DownloadFileFromRepo",
-      "resourceVersion": 1,
-      "minVersion": "3.2",
-      "maxVersion": "7.1",
-      "releasedVersion": "0.0"
-    },
-    {
-      "id": "9946fd70-0d40-406e-b686-b4744cbbcc37",
-      "area": "Location",
-      "resourceName": "ResourceAreas",
-      "routeTemplate": "_apis/{resource}/{areaId}/updatePullRequest",
       "resourceVersion": 1,
       "minVersion": "3.2",
       "maxVersion": "7.1",

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -147,6 +147,16 @@ type VcsClient interface {
 	// description  - Pull request description
 	CreatePullRequest(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) error
 
+	// UpdatePullRequest Updates pull requests metadata
+	// owner        		    - User or organization
+	// repository    		    - VCS repository name
+	// title         	        - Pull request title
+	// body                     - Pull request body or description
+	// targetBranchName         - Name of the pull request target branch name,For non-change, leave the field unfilled.
+	// prId				        - Pull request ID
+	// state				    - Pull request state
+	UpdatePullRequest(ctx context.Context, owner, repository, title, body, targetBranchName string, prId int, state vcsutils.PullRequestState) error
+
 	// AddPullRequestComment Adds a new comment on the requested pull request
 	// owner          - User or organization
 	// repository     - VCS repository name

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -152,7 +152,7 @@ type VcsClient interface {
 	// repository    		    - VCS repository name
 	// title         	        - Pull request title
 	// body                     - Pull request body or description
-	// targetBranchName         - Name of the pull request target branch name,For non-change, leave the field unfilled.
+	// targetBranchName         - Name of the pull request target branch name,For non-change, pass an empty string.
 	// prId				        - Pull request ID
 	// state				    - Pull request state
 	UpdatePullRequest(ctx context.Context, owner, repository, title, body, targetBranchName string, prId int, state vcsutils.PullRequestState) error

--- a/vcsutils/consts.go
+++ b/vcsutils/consts.go
@@ -58,3 +58,10 @@ const (
 	// TagRemoved a tag is removed
 	TagRemoved WebhookEvent = "TagRemoved"
 )
+
+type PullRequestState string
+
+const (
+	Open   PullRequestState = "open"
+	Closed PullRequestState = "closed"
+)

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -314,3 +314,16 @@ func RemapFields[T any](src any, tagName string) (T, error) {
 	}
 	return dst, nil
 }
+
+func MapPullRequestState(state *PullRequestState) *string {
+	var stateStringValue string
+	switch *state {
+	case Open:
+		stateStringValue = "open"
+	case Closed:
+		stateStringValue = "closed"
+	default:
+		return nil
+	}
+	return &stateStringValue
+}

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -1,6 +1,7 @@
 package vcsutils
 
 import (
+	"fmt"
 	"github.com/go-git/go-git/v5"
 	"github.com/stretchr/testify/require"
 	"io"
@@ -260,4 +261,20 @@ func TestRemapFields(t *testing.T) {
 	result, err := RemapFields[destination](src, "some")
 	require.NoError(t, err)
 	require.Equal(t, destination{Name: "John", Birthdate: date}, result)
+}
+
+func TestMapPullRequestState(t *testing.T) {
+	testCases := []struct {
+		state       PullRequestState
+		expected    string
+		gitProvider VcsProvider
+	}{
+		{state: Open, expected: "open", gitProvider: GitHub},
+		{state: Closed, expected: "closed", gitProvider: GitHub},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s-%s", tc.gitProvider.String(), tc.state), func(t *testing.T) {
+			assert.Equal(t, tc.expected, *MapPullRequestState(&tc.state))
+		})
+	}
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---

Adds the ability to update pull request's metadata