### PR TITLE
Standardize ListOpenPullRequest responses

### DIFF
--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"github.com/jfrog/gofrog/datastructures"
-	"google.golang.org/appengine/log"
 	"io"
 	"net/http"
 	"sort"
@@ -372,26 +371,16 @@ func (client *BitbucketServerClient) ListOpenPullRequests(ctx context.Context, o
 				results = append(results, PullRequestInfo{
 					ID: int64(pullRequest.ID),
 					Source: BranchInfo{
-						Name:       bbServerTrimBranchName(pullRequest.FromRef.ID, ctx),
+						Name:       bbServerTrimBranchName(pullRequest.FromRef.ID),
 						Repository: pullRequest.FromRef.Repository.Slug},
 					Target: BranchInfo{
-						Name:       bbServerTrimBranchName(pullRequest.ToRef.ID, ctx),
+						Name:       bbServerTrimBranchName(pullRequest.ToRef.ID),
 						Repository: pullRequest.ToRef.Repository.Slug},
 				})
 			}
 		}
 	}
 	return results, nil
-}
-
-// Trims branch name from ref id which is in the format of head/ref/branchName
-func bbServerTrimBranchName(id string, ctx context.Context) string {
-	split := strings.Split(id, "/")
-	if len(split) < 2 {
-		log.Warningf(ctx, "invalid format, expected ref/head/branchName, received:%s", id)
-		return id
-	}
-	return split[2]
 }
 
 // AddPullRequestComment on Bitbucket server
@@ -752,4 +741,9 @@ func getBitbucketServerRepositoryVisibility(public bool) RepositoryVisibility {
 		return Public
 	}
 	return Private
+}
+
+// Trims branch name from ref id which is in the format of head/ref/branchName
+func bbServerTrimBranchName(id string) string {
+	return strings.Split(id, "/")[2]
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -371,10 +371,10 @@ func (client *BitbucketServerClient) ListOpenPullRequests(ctx context.Context, o
 				results = append(results, PullRequestInfo{
 					ID: int64(pullRequest.ID),
 					Source: BranchInfo{
-						Name:       bbServerTrimBranchName(pullRequest.FromRef.ID),
+						Name:       pullRequest.FromRef.DisplayID,
 						Repository: pullRequest.FromRef.Repository.Slug},
 					Target: BranchInfo{
-						Name:       bbServerTrimBranchName(pullRequest.ToRef.ID),
+						Name:       pullRequest.ToRef.DisplayID,
 						Repository: pullRequest.ToRef.Repository.Slug},
 				})
 			}
@@ -741,9 +741,4 @@ func getBitbucketServerRepositoryVisibility(public bool) RepositoryVisibility {
 		return Public
 	}
 	return Private
-}
-
-// Trims branch name from ref id which is in the format of head/ref/branchName
-func bbServerTrimBranchName(id string) string {
-	return strings.Split(id, "/")[2]
 }

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -225,8 +225,8 @@ func TestBitbucketServer_ListOpenPullRequests(t *testing.T) {
 	assert.Len(t, result, 1)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     101,
-		Source: BranchInfo{Name: "refs/heads/feature-ABC-123", Repository: "my-repo"},
-		Target: BranchInfo{Name: "refs/heads/master", Repository: "my-repo"},
+		Source: BranchInfo{Name: "feature-ABC-123", Repository: "my-repo"},
+		Target: BranchInfo{Name: "master", Repository: "my-repo"},
 	}, result[0]))
 }
 

--- a/vcsclient/testdata/bitbucketserver/pull_requests_list_response.json
+++ b/vcsclient/testdata/bitbucketserver/pull_requests_list_response.json
@@ -21,7 +21,8 @@
                     "project": {
                         "key": "PRJ"
                     }
-                }
+                },
+                "displayId": "feature-ABC-123"
             },
             "toRef": {
                 "id": "refs/heads/master",
@@ -31,7 +32,8 @@
                     "project": {
                         "key": "PRJ"
                     }
-                }
+                },
+                "displayId": "master"
             },
             "locked": false,
             "author": {


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---
Unify the response format of the function ListOpenPullRequest.
Returning only branch name as the ID in all VCS providers.
In Bitbucket Server it used to return with ref/head/branchName.
