### PR TITLE
Add owner attribute to BranchInfo

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -17,6 +17,8 @@ import (
 	"time"
 )
 
+const defaultAzureBaseUrl = "https://dev.azure.com/"
+
 // Azure Devops API version 6
 type AzureReposClient struct {
 	vcsInfo           VcsInfo
@@ -598,11 +600,10 @@ func extractOwnerFromForkedRepoUrl(forkedGit *git.GitForkRef) string {
 		return ""
 	}
 	url := *forkedGit.Repository.Url
-	owner := strings.Split(strings.TrimPrefix(url, "https://dev.azure.com/"), "/")[0]
-	// Failed to properly extract owner name
-	if strings.Contains(owner, "http") {
+	if !strings.Contains(url, defaultAzureBaseUrl) {
 		return ""
 	}
+	owner := strings.Split(strings.TrimPrefix(url, defaultAzureBaseUrl), "/")[0]
 	return owner
 }
 

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -258,16 +258,16 @@ func (client *AzureReposClient) ListPullRequestComments(ctx context.Context, _, 
 }
 
 // ListOpenPullRequestsWithBody on Azure Repos
-func (client *AzureReposClient) ListOpenPullRequestsWithBody(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
-	return client.getOpenPullRequests(ctx, owner, repository, true)
+func (client *AzureReposClient) ListOpenPullRequestsWithBody(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
+	return client.getOpenPullRequests(ctx, repository, true)
 }
 
 // ListOpenPullRequests on Azure Repos
-func (client *AzureReposClient) ListOpenPullRequests(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
-	return client.getOpenPullRequests(ctx, owner, repository, false)
+func (client *AzureReposClient) ListOpenPullRequests(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
+	return client.getOpenPullRequests(ctx, repository, false)
 }
 
-func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, owner, repository string, withBody bool) ([]PullRequestInfo, error) {
+func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, repository string, withBody bool) ([]PullRequestInfo, error) {
 	azureReposGitClient, err := client.buildAzureReposClient(ctx)
 	if err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, owner, 
 	}
 	var pullRequestsInfo []PullRequestInfo
 	for _, pullRequest := range *pullRequests {
-		pullRequestDetails := parsePullRequestDetails(pullRequest, repository, owner)
+		pullRequestDetails := parsePullRequestDetails(pullRequest, repository)
 		pullRequestsInfo = append(pullRequestsInfo, pullRequestDetails)
 	}
 	return pullRequestsInfo, nil
@@ -302,7 +302,7 @@ func (client *AzureReposClient) GetPullRequestByID(ctx context.Context, owner, r
 	if err != nil {
 		return
 	}
-	pullRequestInfo = parsePullRequestDetails(*pullRequest, repository, owner)
+	pullRequestInfo = parsePullRequestDetails(*pullRequest, repository)
 	return
 }
 
@@ -557,16 +557,10 @@ func (client *AzureReposClient) GetModifiedFiles(ctx context.Context, _, reposit
 	return fileNamesList, nil
 }
 
-func parsePullRequestDetails(pullRequest git.GitPullRequest, repository, owner string) PullRequestInfo {
+func parsePullRequestDetails(pullRequest git.GitPullRequest, repository string) PullRequestInfo {
 	// Trim the branches prefix and get the actual branches name
 	shortSourceName := (*pullRequest.SourceRefName)[strings.LastIndex(*pullRequest.SourceRefName, "/")+1:]
 	shortTargetName := (*pullRequest.TargetRefName)[strings.LastIndex(*pullRequest.TargetRefName, "/")+1:]
-
-	// In the case of forked repositories, owners can differ.
-	forkedRepositoryOwner := owner
-	if pullRequest.ForkSource != nil {
-		forkedRepositoryOwner = strings.Split(strings.TrimPrefix(*pullRequest.ForkSource.Url, "https://dev.azure.com/"), "/")[0]
-	}
 
 	var prBody string
 	bodyPtr := pullRequest.Description
@@ -580,12 +574,10 @@ func parsePullRequestDetails(pullRequest git.GitPullRequest, repository, owner s
 		Source: BranchInfo{
 			Name:       shortSourceName,
 			Repository: repository,
-			Owner:      forkedRepositoryOwner,
 		},
 		Target: BranchInfo{
 			Name:       shortTargetName,
 			Repository: repository,
-			Owner:      owner,
 		},
 	}
 }

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -258,16 +258,16 @@ func (client *AzureReposClient) ListPullRequestComments(ctx context.Context, _, 
 }
 
 // ListOpenPullRequestsWithBody on Azure Repos
-func (client *AzureReposClient) ListOpenPullRequestsWithBody(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
-	return client.getOpenPullRequests(ctx, repository, true)
+func (client *AzureReposClient) ListOpenPullRequestsWithBody(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
+	return client.getOpenPullRequests(ctx, owner, repository, true)
 }
 
 // ListOpenPullRequests on Azure Repos
-func (client *AzureReposClient) ListOpenPullRequests(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
-	return client.getOpenPullRequests(ctx, repository, false)
+func (client *AzureReposClient) ListOpenPullRequests(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
+	return client.getOpenPullRequests(ctx, owner, repository, false)
 }
 
-func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, repository string, withBody bool) ([]PullRequestInfo, error) {
+func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, owner, repository string, withBody bool) ([]PullRequestInfo, error) {
 	azureReposGitClient, err := client.buildAzureReposClient(ctx)
 	if err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, reposit
 	}
 	var pullRequestsInfo []PullRequestInfo
 	for _, pullRequest := range *pullRequests {
-		pullRequestDetails := parsePullRequestDetails(pullRequest, repository)
+		pullRequestDetails := parsePullRequestDetails(pullRequest, repository, owner)
 		pullRequestsInfo = append(pullRequestsInfo, pullRequestDetails)
 	}
 	return pullRequestsInfo, nil
@@ -302,7 +302,7 @@ func (client *AzureReposClient) GetPullRequestByID(ctx context.Context, owner, r
 	if err != nil {
 		return
 	}
-	pullRequestInfo = parsePullRequestDetails(*pullRequest, repository)
+	pullRequestInfo = parsePullRequestDetails(*pullRequest, repository, owner)
 	return
 }
 
@@ -557,10 +557,16 @@ func (client *AzureReposClient) GetModifiedFiles(ctx context.Context, _, reposit
 	return fileNamesList, nil
 }
 
-func parsePullRequestDetails(pullRequest git.GitPullRequest, repository string) PullRequestInfo {
+func parsePullRequestDetails(pullRequest git.GitPullRequest, repository, owner string) PullRequestInfo {
 	// Trim the branches prefix and get the actual branches name
 	shortSourceName := (*pullRequest.SourceRefName)[strings.LastIndex(*pullRequest.SourceRefName, "/")+1:]
 	shortTargetName := (*pullRequest.TargetRefName)[strings.LastIndex(*pullRequest.TargetRefName, "/")+1:]
+
+	// In the case of forked repositories, owners can differ.
+	forkedRepositoryOwner := owner
+	if pullRequest.ForkSource != nil {
+		forkedRepositoryOwner = strings.Split(strings.TrimPrefix(*pullRequest.ForkSource.Url, "https://dev.azure.com/"), "/")[0]
+	}
 
 	var prBody string
 	bodyPtr := pullRequest.Description
@@ -574,10 +580,12 @@ func parsePullRequestDetails(pullRequest git.GitPullRequest, repository string) 
 		Source: BranchInfo{
 			Name:       shortSourceName,
 			Repository: repository,
+			Owner:      forkedRepositoryOwner,
 		},
 		Target: BranchInfo{
 			Name:       shortTargetName,
 			Repository: repository,
+			Owner:      owner,
 		},
 	}
 }

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -258,16 +258,16 @@ func (client *AzureReposClient) ListPullRequestComments(ctx context.Context, _, 
 }
 
 // ListOpenPullRequestsWithBody on Azure Repos
-func (client *AzureReposClient) ListOpenPullRequestsWithBody(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
-	return client.getOpenPullRequests(ctx, repository, true)
+func (client *AzureReposClient) ListOpenPullRequestsWithBody(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
+	return client.getOpenPullRequests(ctx, owner, repository, true)
 }
 
 // ListOpenPullRequests on Azure Repos
-func (client *AzureReposClient) ListOpenPullRequests(ctx context.Context, _, repository string) ([]PullRequestInfo, error) {
-	return client.getOpenPullRequests(ctx, repository, false)
+func (client *AzureReposClient) ListOpenPullRequests(ctx context.Context, owner, repository string) ([]PullRequestInfo, error) {
+	return client.getOpenPullRequests(ctx, owner, repository, false)
 }
 
-func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, repository string, withBody bool) ([]PullRequestInfo, error) {
+func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, owner, repository string, withBody bool) ([]PullRequestInfo, error) {
 	azureReposGitClient, err := client.buildAzureReposClient(ctx)
 	if err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func (client *AzureReposClient) getOpenPullRequests(ctx context.Context, reposit
 	}
 	var pullRequestsInfo []PullRequestInfo
 	for _, pullRequest := range *pullRequests {
-		pullRequestDetails := parsePullRequestDetails(pullRequest, repository)
+		pullRequestDetails := parsePullRequestDetails(pullRequest, owner, repository)
 		pullRequestsInfo = append(pullRequestsInfo, pullRequestDetails)
 	}
 	return pullRequestsInfo, nil
@@ -302,7 +302,7 @@ func (client *AzureReposClient) GetPullRequestByID(ctx context.Context, owner, r
 	if err != nil {
 		return
 	}
-	pullRequestInfo = parsePullRequestDetails(*pullRequest, repository)
+	pullRequestInfo = parsePullRequestDetails(*pullRequest, owner, repository)
 	return
 }
 
@@ -557,7 +557,7 @@ func (client *AzureReposClient) GetModifiedFiles(ctx context.Context, _, reposit
 	return fileNamesList, nil
 }
 
-func parsePullRequestDetails(pullRequest git.GitPullRequest, repository string) PullRequestInfo {
+func parsePullRequestDetails(pullRequest git.GitPullRequest, owner, repository string) PullRequestInfo {
 	// Trim the branches prefix and get the actual branches name
 	shortSourceName := (*pullRequest.SourceRefName)[strings.LastIndex(*pullRequest.SourceRefName, "/")+1:]
 	shortTargetName := (*pullRequest.TargetRefName)[strings.LastIndex(*pullRequest.TargetRefName, "/")+1:]
@@ -574,10 +574,12 @@ func parsePullRequestDetails(pullRequest git.GitPullRequest, repository string) 
 		Source: BranchInfo{
 			Name:       shortSourceName,
 			Repository: repository,
+			Owner:      owner,
 		},
 		Target: BranchInfo{
 			Name:       shortTargetName,
 			Repository: repository,
+			Owner:      owner,
 		},
 	}
 }

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -204,11 +204,9 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, "getPullRequests", createAzureReposHandler)
 	defer cleanUp()
-	pullRequestsInfo, err := client.ListOpenPullRequests(ctx, owner, repo1)
+	pullRequestsInfo, err := client.ListOpenPullRequests(ctx, "", repo1)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{
-		{ID: 1, Source: BranchInfo{Name: branch1, Repository: repo1, Owner: owner},
-			Target: BranchInfo{Name: branch2, Repository: repo1, Owner: owner}}}))
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{{ID: 1, Source: BranchInfo{Name: branch1, Repository: repo1}, Target: BranchInfo{Name: branch2, Repository: repo1}}}))
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
@@ -234,11 +232,9 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 	ctx = context.Background()
 	client, cleanUp = createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, "getPullRequests", createAzureReposHandler)
 	defer cleanUp()
-	pullRequestsInfo, err = client.ListOpenPullRequestsWithBody(ctx, owner, repo1)
+	pullRequestsInfo, err = client.ListOpenPullRequestsWithBody(ctx, "", repo1)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{
-		{ID: 1, Body: prBody, Source: BranchInfo{Name: branch1, Repository: repo1, Owner: owner},
-			Target: BranchInfo{Name: branch2, Repository: repo1, Owner: owner}}}))
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{{ID: 1, Body: prBody, Source: BranchInfo{Name: branch1, Repository: repo1}, Target: BranchInfo{Name: branch2, Repository: repo1}}}))
 
 	badClient, cleanUp = createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
@@ -261,48 +257,13 @@ func TestAzureReposClient_GetPullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, fmt.Sprintf("getPullRequests/%d", pullRequestId), createAzureReposHandler)
 	defer cleanUp()
-	pullRequestsInfo, err := client.GetPullRequestByID(ctx, owner, repoName, pullRequestId)
+	pullRequestsInfo, err := client.GetPullRequestByID(ctx, "", repoName, pullRequestId)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1,
-		Source: BranchInfo{Name: sourceName, Repository: repoName, Owner: owner},
-		Target: BranchInfo{Name: targetName, Repository: repoName, Owner: owner}}))
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1, Source: BranchInfo{Name: sourceName, Repository: repoName}, Target: BranchInfo{Name: targetName, Repository: repoName}}))
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
-	_, err = badClient.GetPullRequestByID(ctx, owner, repo1, pullRequestId)
-	assert.Error(t, err)
-}
-
-func TestAzureReposClient_GetPullRequestForked(t *testing.T) {
-	// In the case of a pull request from a forked source, need to parse from the URL the forked repository owner
-	pullRequestId := 1
-	repoName := "repoName"
-	sourceName := "source"
-	targetName := "master"
-	forkedOwner := "forkedOwner"
-	url := fmt.Sprintf("https://dev.azure.com/%s/201f2c7f-305a-446c-a1d6-a04ec811093b/_apis/git/repositories/a00a54c3-9acb-4157-a1f5-8036e5d05a48/pullRequests/4", forkedOwner)
-	res := git.GitPullRequest{
-		SourceRefName: &sourceName,
-		TargetRefName: &targetName,
-		PullRequestId: &pullRequestId,
-		ForkSource: &git.GitForkRef{
-			Url: &url,
-		},
-	}
-	jsonRes, err := json.Marshal(res)
-	assert.NoError(t, err)
-	ctx := context.Background()
-	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, fmt.Sprintf("getPullRequests/%d", pullRequestId), createAzureReposHandler)
-	defer cleanUp()
-	pullRequestsInfo, err := client.GetPullRequestByID(ctx, owner, repoName, pullRequestId)
-	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1,
-		Source: BranchInfo{Name: sourceName, Repository: repoName, Owner: forkedOwner},
-		Target: BranchInfo{Name: targetName, Repository: repoName, Owner: owner}}))
-
-	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
-	defer cleanUp()
-	_, err = badClient.GetPullRequestByID(ctx, owner, repo1, pullRequestId)
+	_, err = badClient.GetPullRequestByID(ctx, "", repo1, pullRequestId)
 	assert.Error(t, err)
 }
 

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -204,9 +204,11 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, "getPullRequests", createAzureReposHandler)
 	defer cleanUp()
-	pullRequestsInfo, err := client.ListOpenPullRequests(ctx, "", repo1)
+	pullRequestsInfo, err := client.ListOpenPullRequests(ctx, owner, repo1)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{{ID: 1, Source: BranchInfo{Name: branch1, Repository: repo1}, Target: BranchInfo{Name: branch2, Repository: repo1}}}))
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{
+		{ID: 1, Source: BranchInfo{Name: branch1, Repository: repo1, Owner: owner},
+			Target: BranchInfo{Name: branch2, Repository: repo1, Owner: owner}}}))
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
@@ -232,9 +234,11 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 	ctx = context.Background()
 	client, cleanUp = createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, "getPullRequests", createAzureReposHandler)
 	defer cleanUp()
-	pullRequestsInfo, err = client.ListOpenPullRequestsWithBody(ctx, "", repo1)
+	pullRequestsInfo, err = client.ListOpenPullRequestsWithBody(ctx, owner, repo1)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{{ID: 1, Body: prBody, Source: BranchInfo{Name: branch1, Repository: repo1}, Target: BranchInfo{Name: branch2, Repository: repo1}}}))
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, []PullRequestInfo{
+		{ID: 1, Body: prBody, Source: BranchInfo{Name: branch1, Repository: repo1, Owner: owner},
+			Target: BranchInfo{Name: branch2, Repository: repo1, Owner: owner}}}))
 
 	badClient, cleanUp = createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
@@ -257,13 +261,48 @@ func TestAzureReposClient_GetPullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, fmt.Sprintf("getPullRequests/%d", pullRequestId), createAzureReposHandler)
 	defer cleanUp()
-	pullRequestsInfo, err := client.GetPullRequestByID(ctx, "", repoName, pullRequestId)
+	pullRequestsInfo, err := client.GetPullRequestByID(ctx, owner, repoName, pullRequestId)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1, Source: BranchInfo{Name: sourceName, Repository: repoName}, Target: BranchInfo{Name: targetName, Repository: repoName}}))
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1,
+		Source: BranchInfo{Name: sourceName, Repository: repoName, Owner: owner},
+		Target: BranchInfo{Name: targetName, Repository: repoName, Owner: owner}}))
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
-	_, err = badClient.GetPullRequestByID(ctx, "", repo1, pullRequestId)
+	_, err = badClient.GetPullRequestByID(ctx, owner, repo1, pullRequestId)
+	assert.Error(t, err)
+}
+
+func TestAzureReposClient_GetPullRequestForked(t *testing.T) {
+	// In the case of a pull request from a forked source, need to parse from the URL the forked repository owner
+	pullRequestId := 1
+	repoName := "repoName"
+	sourceName := "source"
+	targetName := "master"
+	forkedOwner := "forkedOwner"
+	url := fmt.Sprintf("https://dev.azure.com/%s/201f2c7f-305a-446c-a1d6-a04ec811093b/_apis/git/repositories/a00a54c3-9acb-4157-a1f5-8036e5d05a48/pullRequests/4", forkedOwner)
+	res := git.GitPullRequest{
+		SourceRefName: &sourceName,
+		TargetRefName: &targetName,
+		PullRequestId: &pullRequestId,
+		ForkSource: &git.GitForkRef{
+			Url: &url,
+		},
+	}
+	jsonRes, err := json.Marshal(res)
+	assert.NoError(t, err)
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, fmt.Sprintf("getPullRequests/%d", pullRequestId), createAzureReposHandler)
+	defer cleanUp()
+	pullRequestsInfo, err := client.GetPullRequestByID(ctx, owner, repoName, pullRequestId)
+	assert.NoError(t, err)
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1,
+		Source: BranchInfo{Name: sourceName, Repository: repoName, Owner: forkedOwner},
+		Target: BranchInfo{Name: targetName, Repository: repoName, Owner: owner}}))
+
+	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
+	defer cleanUp()
+	_, err = badClient.GetPullRequestByID(ctx, owner, repo1, pullRequestId)
 	assert.Error(t, err)
 }
 

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -257,13 +257,15 @@ func TestAzureReposClient_GetPullRequest(t *testing.T) {
 	ctx := context.Background()
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, jsonRes, fmt.Sprintf("getPullRequests/%d", pullRequestId), createAzureReposHandler)
 	defer cleanUp()
-	pullRequestsInfo, err := client.GetPullRequestByID(ctx, "", repoName, pullRequestId)
+	pullRequestsInfo, err := client.GetPullRequestByID(ctx, owner, repoName, pullRequestId)
 	assert.NoError(t, err)
-	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1, Source: BranchInfo{Name: sourceName, Repository: repoName}, Target: BranchInfo{Name: targetName, Repository: repoName}}))
+	assert.True(t, reflect.DeepEqual(pullRequestsInfo, PullRequestInfo{ID: 1,
+		Source: BranchInfo{Name: sourceName, Repository: repoName, Owner: owner},
+		Target: BranchInfo{Name: targetName, Repository: repoName, Owner: owner}}))
 
 	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
 	defer cleanUp()
-	_, err = badClient.GetPullRequestByID(ctx, "", repo1, pullRequestId)
+	_, err = badClient.GetPullRequestByID(ctx, owner, repo1, pullRequestId)
 	assert.Error(t, err)
 }
 

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -370,8 +370,8 @@ func (client *BitbucketCloudClient) GetPullRequestByID(ctx context.Context, owne
 		return
 	}
 
-	sourceOwner, sourceRepository := splitWorkSpaceAndOwner(pullRequestDetails.Source.Repository.Name)
-	targetOwner, targetRepository := splitWorkSpaceAndOwner(pullRequestDetails.Target.Repository.Name)
+	sourceOwner, sourceRepository := splitBitbucketCloudRepoName(pullRequestDetails.Source.Repository.Name)
+	targetOwner, targetRepository := splitBitbucketCloudRepoName(pullRequestDetails.Target.Repository.Name)
 
 	pullRequestInfo = PullRequestInfo{
 		ID: pullRequestDetails.ID,
@@ -789,7 +789,9 @@ func getBitbucketCloudRepositoryVisibility(repo *bitbucket.Repository) Repositor
 	return Public
 }
 
-func splitWorkSpaceAndOwner(name string) (string, string) {
+// Bitbucket cloud repository name is a combination of workspace/repository
+// Return the two separate elements
+func splitBitbucketCloudRepoName(name string) (string, string) {
 	split := strings.Split(name, "/")
 	if len(split) < 2 {
 		return "", ""

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -370,8 +370,8 @@ func (client *BitbucketCloudClient) GetPullRequestByID(ctx context.Context, owne
 		return
 	}
 
-	sourceRepository, sourceOwner := splitWorkSpaceAndOwner(pullRequestDetails.Source.Repository.Name)
-	targetRepository, targetOwner := splitWorkSpaceAndOwner(pullRequestDetails.Source.Repository.Name)
+	sourceOwner, sourceRepository := splitWorkSpaceAndOwner(pullRequestDetails.Source.Repository.Name)
+	targetOwner, targetRepository := splitWorkSpaceAndOwner(pullRequestDetails.Target.Repository.Name)
 
 	pullRequestInfo = PullRequestInfo{
 		ID: pullRequestDetails.ID,

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -369,17 +369,21 @@ func (client *BitbucketCloudClient) GetPullRequestByID(ctx context.Context, owne
 	if err != nil {
 		return
 	}
+
+	sourceRepository, sourceOwner := splitWorkSpaceAndOwner(pullRequestDetails.Source.Repository.Name)
+	targetRepository, targetOwner := splitWorkSpaceAndOwner(pullRequestDetails.Source.Repository.Name)
+
 	pullRequestInfo = PullRequestInfo{
 		ID: pullRequestDetails.ID,
 		Source: BranchInfo{
 			Name:       pullRequestDetails.Source.Name.Str,
-			Repository: pullRequestDetails.Source.Repository.Name,
-			Owner:      owner,
+			Repository: sourceRepository,
+			Owner:      sourceOwner,
 		},
 		Target: BranchInfo{
 			Name:       pullRequestDetails.Target.Name.Str,
-			Repository: pullRequestDetails.Target.Repository.Name,
-			Owner:      owner,
+			Repository: targetRepository,
+			Owner:      targetOwner,
 		},
 	}
 	return
@@ -783,4 +787,12 @@ func getBitbucketCloudRepositoryVisibility(repo *bitbucket.Repository) Repositor
 		return Private
 	}
 	return Public
+}
+
+func splitWorkSpaceAndOwner(name string) (string, string) {
+	split := strings.Split(name, "/")
+	if len(split) < 2 {
+		return "", ""
+	}
+	return split[0], split[1]
 }

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -374,10 +374,12 @@ func (client *BitbucketCloudClient) GetPullRequestByID(ctx context.Context, owne
 		Source: BranchInfo{
 			Name:       pullRequestDetails.Source.Name.Str,
 			Repository: pullRequestDetails.Source.Repository.Name,
+			Owner:      owner,
 		},
 		Target: BranchInfo{
 			Name:       pullRequestDetails.Target.Name.Str,
 			Repository: pullRequestDetails.Target.Repository.Name,
+			Owner:      owner,
 		},
 	}
 	return

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -212,7 +212,7 @@ func TestBitbucketCloudClient_GetPullRequest(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
 		Source: BranchInfo{Name: "pr", Repository: "froggit", Owner: "forkedWorkspace"},
-		Target: BranchInfo{Name: "main", Repository: "froggit", Owner: owner},
+		Target: BranchInfo{Name: "main", Repository: "froggit", Owner: "workspace"},
 	}, result))
 
 	// Bad Response

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -573,12 +573,12 @@ func TestBitbucketCloudClient_GetCommitStatus(t *testing.T) {
 
 func TestSplitWorkSpaceAndOwner(t *testing.T) {
 	valid := "work/repo"
-	workspace, repo := splitWorkSpaceAndOwner(valid)
+	workspace, repo := splitBitbucketCloudRepoName(valid)
 	assert.Equal(t, "work", workspace)
 	assert.Equal(t, "repo", repo)
 
 	invalid := "workrepo"
-	workspace, repo = splitWorkSpaceAndOwner(invalid)
+	workspace, repo = splitBitbucketCloudRepoName(invalid)
 	assert.Equal(t, "", workspace)
 	assert.Equal(t, "", repo)
 }

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -211,8 +211,8 @@ func TestBitbucketCloudClient_GetPullRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "pr", Repository: "workspace/froggit"},
-		Target: BranchInfo{Name: "main", Repository: "workspace/froggit"},
+		Source: BranchInfo{Name: "pr", Repository: "workspace/froggit", Owner: owner},
+		Target: BranchInfo{Name: "main", Repository: "workspace/froggit", Owner: owner},
 	}, result))
 
 	// Bad Response

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -211,8 +211,8 @@ func TestBitbucketCloudClient_GetPullRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "pr", Repository: "workspace/froggit", Owner: owner},
-		Target: BranchInfo{Name: "main", Repository: "workspace/froggit", Owner: owner},
+		Source: BranchInfo{Name: "pr", Repository: "froggit", Owner: "forkedWorkspace"},
+		Target: BranchInfo{Name: "main", Repository: "froggit", Owner: owner},
 	}, result))
 
 	// Bad Response
@@ -569,6 +569,18 @@ func TestBitbucketCloudClient_GetCommitStatus(t *testing.T) {
 		assert.True(t, commitStatuses[1].State == Pass)
 		assert.True(t, commitStatuses[2].State == Fail)
 	})
+}
+
+func TestSplitWorkSpaceAndOwner(t *testing.T) {
+	valid := "work/repo"
+	workspace, repo := splitWorkSpaceAndOwner(valid)
+	assert.Equal(t, "work", workspace)
+	assert.Equal(t, "repo", repo)
+
+	invalid := "workrepo"
+	workspace, repo = splitWorkSpaceAndOwner(invalid)
+	assert.Equal(t, "", workspace)
+	assert.Equal(t, "", repo)
 }
 
 func createBitbucketCloudHandler(t *testing.T, expectedURI string, response []byte, expectedStatusCode int) http.HandlerFunc {

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -412,11 +412,12 @@ func (client *BitbucketServerClient) GetPullRequestByID(ctx context.Context, own
 	if err != nil {
 		return
 	}
-	if pullRequest.FromRef.Repository.Project == nil {
+	project := pullRequest.FromRef.Repository.Project
+	if project == nil {
 		err = fmt.Errorf("failed to get source repository owner, project is nil")
 		return
 	}
-	sourceOwner := pullRequest.FromRef.Repository.Project.Key
+	sourceOwner := project.Key
 	pullRequestInfo = PullRequestInfo{
 		ID:     int64(pullRequest.ID),
 		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: sourceOwner},

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -414,8 +414,8 @@ func (client *BitbucketServerClient) GetPullRequestByID(ctx context.Context, own
 	}
 	pullRequestInfo = PullRequestInfo{
 		ID:     int64(pullRequest.ID),
-		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: pullRequest.ToRef.Repository.Project.Key},
-		Target: BranchInfo{Name: pullRequest.ToRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: pullRequest.ToRef.Repository.Project.Key},
+		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug},
+		Target: BranchInfo{Name: pullRequest.ToRef.ID, Repository: pullRequest.ToRef.Repository.Slug},
 	}
 	return
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -412,9 +412,11 @@ func (client *BitbucketServerClient) GetPullRequestByID(ctx context.Context, own
 	if err != nil {
 		return
 	}
+	// Could differ from a forked repository
+	sourceOwner := pullRequest.FromRef.Repository.Project.Key
 	pullRequestInfo = PullRequestInfo{
 		ID:     int64(pullRequest.ID),
-		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: owner},
+		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: sourceOwner},
 		Target: BranchInfo{Name: pullRequest.ToRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: owner},
 	}
 	return

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -414,8 +414,8 @@ func (client *BitbucketServerClient) GetPullRequestByID(ctx context.Context, own
 	}
 	pullRequestInfo = PullRequestInfo{
 		ID:     int64(pullRequest.ID),
-		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug},
-		Target: BranchInfo{Name: pullRequest.ToRef.ID, Repository: pullRequest.ToRef.Repository.Slug},
+		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: pullRequest.ToRef.Repository.Project.Key},
+		Target: BranchInfo{Name: pullRequest.ToRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: pullRequest.ToRef.Repository.Project.Key},
 	}
 	return
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -412,7 +412,10 @@ func (client *BitbucketServerClient) GetPullRequestByID(ctx context.Context, own
 	if err != nil {
 		return
 	}
-	// Could differ from a forked repository
+	if pullRequest.FromRef.Repository.Project == nil {
+		err = fmt.Errorf("failed to get source repository owner, project is nil")
+		return
+	}
 	sourceOwner := pullRequest.FromRef.Repository.Project.Key
 	pullRequestInfo = PullRequestInfo{
 		ID:     int64(pullRequest.ID),

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -414,8 +414,8 @@ func (client *BitbucketServerClient) GetPullRequestByID(ctx context.Context, own
 	}
 	pullRequestInfo = PullRequestInfo{
 		ID:     int64(pullRequest.ID),
-		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug},
-		Target: BranchInfo{Name: pullRequest.ToRef.ID, Repository: pullRequest.ToRef.Repository.Slug},
+		Source: BranchInfo{Name: pullRequest.FromRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: owner},
+		Target: BranchInfo{Name: pullRequest.ToRef.ID, Repository: pullRequest.ToRef.Repository.Slug, Owner: owner},
 	}
 	return
 }

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -256,8 +256,8 @@ func TestBitbucketServerClient_GetPullRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName", Owner: "~owner"},
-		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName", Owner: "~owner"},
+		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName"},
+		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName"},
 	}, result))
 
 	// Bad response

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -256,8 +256,8 @@ func TestBitbucketServerClient_GetPullRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName"},
-		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName"},
+		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName", Owner: "repoOwner"},
+		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName", Owner: "repoOwner"},
 	}, result))
 
 	// Bad response

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -256,7 +256,7 @@ func TestBitbucketServerClient_GetPullRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName", Owner: owner},
+		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName", Owner: "~fromOwner"},
 		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName", Owner: owner},
 	}, result))
 

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -260,6 +260,15 @@ func TestBitbucketServerClient_GetPullRequest(t *testing.T) {
 		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName", Owner: owner},
 	}, result))
 
+	// Failed owner extraction
+	response, err = os.ReadFile(filepath.Join("testdata", "bitbucketserver", "get_pull_request_response_nil.json"))
+	assert.NoError(t, err)
+	ownerClient, ownerCleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, response,
+		fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d", owner, repo1, pullRequestId), createBitbucketServerHandler)
+	defer ownerCleanUp()
+	_, err = ownerClient.GetPullRequestByID(ctx, owner, repo1, pullRequestId)
+	assert.Error(t, err)
+
 	// Bad response
 	badClient, badClientCleanUp := createServerAndClient(t, vcsutils.BitbucketServer, true, "{",
 		fmt.Sprintf("/rest/api/1.0/projects/%s/repos/%s/pull-requests/%d", owner, repo1, pullRequestId), createBitbucketServerHandler)

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -256,8 +256,8 @@ func TestBitbucketServerClient_GetPullRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName"},
-		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName"},
+		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName", Owner: owner},
+		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName", Owner: owner},
 	}, result))
 
 	// Bad response

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -256,8 +256,8 @@ func TestBitbucketServerClient_GetPullRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName", Owner: "repoOwner"},
-		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName", Owner: "repoOwner"},
+		Source: BranchInfo{Name: "refs/heads/new_vul_2", Repository: "repoName", Owner: "~owner"},
+		Target: BranchInfo{Name: "refs/heads/master", Repository: "repoName", Owner: "~owner"},
 	}, result))
 
 	// Bad response

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -330,8 +330,8 @@ func (client *GitHubClient) GetPullRequestByID(ctx context.Context, owner, repos
 		return PullRequestInfo{}, err
 	}
 
-	sourceBranch, err1 := extractBranchFromLabel(*pullRequest.Head.Label)
-	targetBranch, err2 := extractBranchFromLabel(*pullRequest.Base.Label)
+	sourceBranch, err1 := extractBranchFromLabel(vcsutils.DefaultIfNotNil(pullRequest.Head.Label))
+	targetBranch, err2 := extractBranchFromLabel(vcsutils.DefaultIfNotNil(pullRequest.Base.Label))
 	err = errors.Join(err1, err2)
 	if err != nil {
 		return PullRequestInfo{}, err
@@ -341,13 +341,13 @@ func (client *GitHubClient) GetPullRequestByID(ctx context.Context, owner, repos
 		ID: int64(pullRequestId),
 		Source: BranchInfo{
 			Name:       sourceBranch,
-			Repository: *pullRequest.Head.Repo.Name,
-			Owner:      *pullRequest.Head.Repo.Owner.Login,
+			Repository: vcsutils.DefaultIfNotNil(pullRequest.Head.Repo.Name),
+			Owner:      vcsutils.DefaultIfNotNil(pullRequest.Head.Repo.Owner.Login),
 		},
 		Target: BranchInfo{
 			Name:       targetBranch,
-			Repository: *pullRequest.Base.Repo.Name,
-			Owner:      *pullRequest.Base.Repo.Owner.Login,
+			Repository: vcsutils.DefaultIfNotNil(pullRequest.Base.Repo.Name),
+			Owner:      vcsutils.DefaultIfNotNil(pullRequest.Base.Repo.Owner.Login),
 		},
 	}
 	return prInfo, nil

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -816,10 +816,12 @@ func mapGitHubPullRequestToPullRequestInfoList(pullRequestList []*github.PullReq
 			Source: BranchInfo{
 				Name:       *pullRequest.Head.Ref,
 				Repository: *pullRequest.Head.Repo.Name,
+				Owner:      *pullRequest.Head.Repo.Owner.Login,
 			},
 			Target: BranchInfo{
 				Name:       *pullRequest.Base.Ref,
 				Repository: *pullRequest.Base.Repo.Name,
+				Owner:      *pullRequest.Base.Repo.Owner.Login,
 			},
 		})
 	}

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -342,10 +342,12 @@ func (client *GitHubClient) GetPullRequestByID(ctx context.Context, owner, repos
 		Source: BranchInfo{
 			Name:       sourceBranch,
 			Repository: *pullRequest.Head.Repo.Name,
+			Owner:      *pullRequest.Head.Repo.Owner.Name,
 		},
 		Target: BranchInfo{
 			Name:       targetBranch,
 			Repository: *pullRequest.Base.Repo.Name,
+			Owner:      *pullRequest.Base.Repo.Owner.Name,
 		},
 	}
 	return prInfo, nil

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -342,12 +342,12 @@ func (client *GitHubClient) GetPullRequestByID(ctx context.Context, owner, repos
 		Source: BranchInfo{
 			Name:       sourceBranch,
 			Repository: *pullRequest.Head.Repo.Name,
-			Owner:      *pullRequest.Head.Repo.Owner.Name,
+			Owner:      *pullRequest.Head.Repo.Owner.Login,
 		},
 		Target: BranchInfo{
 			Name:       targetBranch,
 			Repository: *pullRequest.Base.Repo.Name,
-			Owner:      *pullRequest.Base.Repo.Owner.Name,
+			Owner:      *pullRequest.Base.Repo.Owner.Login,
 		},
 	}
 	return prInfo, nil

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -811,17 +811,17 @@ func mapGitHubPullRequestToPullRequestInfoList(pullRequestList []*github.PullReq
 			body = *pullRequest.Body
 		}
 		res = append(res, PullRequestInfo{
-			ID:   int64(*pullRequest.Number),
+			ID:   int64(vcsutils.DefaultIfNotNil(pullRequest.Number)),
 			Body: body,
 			Source: BranchInfo{
-				Name:       *pullRequest.Head.Ref,
-				Repository: *pullRequest.Head.Repo.Name,
-				Owner:      *pullRequest.Head.Repo.Owner.Login,
+				Name:       vcsutils.DefaultIfNotNil(pullRequest.Head.Ref),
+				Repository: vcsutils.DefaultIfNotNil(pullRequest.Head.Repo.Name),
+				Owner:      vcsutils.DefaultIfNotNil(pullRequest.Head.Repo.Owner.Login),
 			},
 			Target: BranchInfo{
-				Name:       *pullRequest.Base.Ref,
-				Repository: *pullRequest.Base.Repo.Name,
-				Owner:      *pullRequest.Base.Repo.Owner.Login,
+				Name:       vcsutils.DefaultIfNotNil(pullRequest.Base.Ref),
+				Repository: vcsutils.DefaultIfNotNil(pullRequest.Base.Repo.Name),
+				Owner:      vcsutils.DefaultIfNotNil(pullRequest.Base.Repo.Owner.Login),
 			},
 		})
 	}

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -539,8 +539,8 @@ func TestGitHubClient_ListOpenPullRequests(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     1,
-		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World"},
-		Target: BranchInfo{Name: "master", Repository: "Hello-World"},
+		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
+		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: owner},
 	}, result[0]))
 
 	_, err = createBadGitHubClient(t).ListPullRequestComments(ctx, owner, repo1, 1)
@@ -554,8 +554,8 @@ func TestGitHubClient_ListOpenPullRequests(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     1,
 		Body:   "hello world",
-		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World"},
-		Target: BranchInfo{Name: "master", Repository: "Hello-World"},
+		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
+		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: owner},
 	}, result[0]))
 
 	_, err = createBadGitHubClient(t).ListPullRequestComments(ctx, owner, repo1, 1)
@@ -566,8 +566,10 @@ func TestGitHubClient_GetPullRequestByID(t *testing.T) {
 	ctx := context.Background()
 	pullRequestId := 1
 	repoName := "Hello-World"
+	forkedOwner := owner + "Forked"
 
 	// Successful response
+	// This response mimics a pull request from a forked source
 	response, err := os.ReadFile(filepath.Join("testdata", "github", "pull_request_info_response.json"))
 	assert.NoError(t, err)
 	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, response,
@@ -577,8 +579,8 @@ func TestGitHubClient_GetPullRequestByID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: "octocat"},
-		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: "octocat"},
+		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
+		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: forkedOwner},
 	}, result))
 
 	// Bad Labels

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -577,8 +577,8 @@ func TestGitHubClient_GetPullRequestByID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     int64(pullRequestId),
-		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World"},
-		Target: BranchInfo{Name: "master", Repository: "Hello-World"},
+		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: "octocat"},
+		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: "octocat"},
 	}, result))
 
 	// Bad Labels

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -283,8 +283,8 @@ func (client *GitLabClient) GetPullRequestByID(ctx context.Context, owner, repos
 	}
 	pullRequestInfo = PullRequestInfo{
 		ID:     int64(mergeRequest.ID),
-		Source: BranchInfo{Name: mergeRequest.SourceBranch},
-		Target: BranchInfo{Name: mergeRequest.TargetBranch},
+		Source: BranchInfo{Name: mergeRequest.SourceBranch, Repository: repository, Owner: owner},
+		Target: BranchInfo{Name: mergeRequest.TargetBranch, Repository: repository, Owner: owner},
 	}
 	return
 }

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -258,8 +258,8 @@ func TestGitLabClient_GetPullRequestByID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, reflect.DeepEqual(PullRequestInfo{
 		ID:     1,
-		Source: BranchInfo{Name: "manual-job-rules", Repository: ""},
-		Target: BranchInfo{Name: "master", Repository: ""},
+		Source: BranchInfo{Name: "manual-job-rules", Repository: repoName, Owner: owner},
+		Target: BranchInfo{Name: "master", Repository: repoName, Owner: owner},
 	}, result))
 
 	// Bad client

--- a/vcsclient/logger.go
+++ b/vcsclient/logger.go
@@ -9,6 +9,8 @@ const (
 	fetchingOpenPullRequests = "Fetching open pull requests in"
 	fetchingPullRequestById  = "Fetching pull requests by id in"
 	uploadingCodeScanning    = "Uploading code scanning for:"
+
+	failedForkedRepositoryExtraction = "Failed to extract forked repository owner"
 )
 
 type Log interface {

--- a/vcsclient/testdata/bitbucketcloud/get_pull_request_response.json
+++ b/vcsclient/testdata/bitbucketcloud/get_pull_request_response.json
@@ -96,7 +96,7 @@
     },
     "repository": {
       "type": "repository",
-      "full_name": "workspace/froggit",
+      "full_name": "forkedWorkspace/froggit",
       "links": {
         "self": {
           "href": "https://api.bitbucket.org/2.0/repositories/workspace/froggit"

--- a/vcsclient/testdata/bitbucketserver/get_pull_request_response.json
+++ b/vcsclient/testdata/bitbucketserver/get_pull_request_response.json
@@ -32,7 +32,7 @@
         "statusMessage": "Available",
         "forkable": true,
         "project": {
-          "key": "repoOwner",
+          "key": "repoName",
           "id": 100,
           "name": "repoName",
           "description": "repoName",

--- a/vcsclient/testdata/bitbucketserver/get_pull_request_response.json
+++ b/vcsclient/testdata/bitbucketserver/get_pull_request_response.json
@@ -67,7 +67,7 @@
         }
       },
       "project": {
-        "key": "~owner",
+        "key": "~fromOwner",
         "id": 2424,
         "name": "some name",
         "type": "PERSONAL",
@@ -175,7 +175,7 @@
         }
       },
       "project": {
-        "key": "~owner",
+        "key": "~targetOwner",
         "id": 2424,
         "name": "some name",
         "type": "PERSONAL",

--- a/vcsclient/testdata/bitbucketserver/get_pull_request_response.json
+++ b/vcsclient/testdata/bitbucketserver/get_pull_request_response.json
@@ -32,7 +32,7 @@
         "statusMessage": "Available",
         "forkable": true,
         "project": {
-          "key": "repoName",
+          "key": "repoOwner",
           "id": 100,
           "name": "repoName",
           "description": "repoName",

--- a/vcsclient/testdata/bitbucketserver/get_pull_request_response_nil.json
+++ b/vcsclient/testdata/bitbucketserver/get_pull_request_response_nil.json
@@ -1,0 +1,214 @@
+{
+  "id": 6,
+  "version": 0,
+  "title": "New vul 2",
+  "description": "* add vul\n* test",
+  "state": "OPEN",
+  "open": true,
+  "closed": false,
+  "createdDate": 1686651080688,
+  "updatedDate": 1686651080688,
+  "fromRef": {
+    "id": "refs/heads/new_vul_2",
+    "displayId": "new_vul_2",
+    "latestCommit": "7121b72f7c2a4bdd953bcddd80c037cb598db690",
+    "type": "BRANCH",
+    "repository": {
+      "slug": "repoName",
+      "id": 35731,
+      "name": "repoName",
+      "hierarchyId": "38d6f6b604eee2af0b68",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "origin": {
+        "slug": "repoName",
+        "id": 115,
+        "name": "repoName",
+        "hierarchyId": "38d6f3b609eee2af0b68",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "public": false,
+        "archived": false,
+        "links": {
+          "clone": [
+            {
+              "href": "https://git.bbServerHost.info/scm/repoName/repoName.git",
+              "name": "http"
+            },
+            {
+              "href": "ssh://git@git.bbServerHost.info/repoName/repoName.git",
+              "name": "ssh"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://git.bbServerHost.info/projects/repoName/repos/repoName/browse"
+            }
+          ]
+        }
+      },
+      "public": false,
+      "archived": false,
+      "links": {
+        "clone": [
+          {
+            "href": "ssh://git@git.bbServerHost.info/~owner/repoName.git",
+            "name": "ssh"
+          },
+          {
+            "href": "https://git.bbServerHost.info/scm/~owner/repoName.git",
+            "name": "http"
+          }
+        ],
+        "self": [
+          {
+            "href": "https://git.bbServerHost.info/users/owner/repos/repoName/browse"
+          }
+        ]
+      }
+    }
+  },
+  "toRef": {
+    "id": "refs/heads/master",
+    "displayId": "master",
+    "latestCommit": "49ee0968441e2cae00e714c1d7852a6565ce12c7",
+    "type": "BRANCH",
+    "repository": {
+      "slug": "repoName",
+      "id": 32731,
+      "name": "repoName",
+      "hierarchyId": "38d6f4b609eee2af0b68",
+      "scmId": "git",
+      "state": "AVAILABLE",
+      "statusMessage": "Available",
+      "forkable": true,
+      "origin": {
+        "slug": "repoName",
+        "id": 1215,
+        "name": "repoName",
+        "hierarchyId": "38f6f6b609eee2af0b68",
+        "scmId": "git",
+        "state": "AVAILABLE",
+        "statusMessage": "Available",
+        "forkable": true,
+        "project": {
+          "key": "repoName",
+          "id": 1210,
+          "name": "repoName",
+          "description": "repoName",
+          "public": false,
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://git.bbServerHost.info/projects/repoName"
+              }
+            ]
+          }
+        },
+        "public": false,
+        "archived": false,
+        "links": {
+          "clone": [
+            {
+              "href": "https://git.bbServerHost.info/scm/repoName/repoName.git",
+              "name": "http"
+            },
+            {
+              "href": "ssh://git@git.bbServerHost.info/repoName/repoName.git",
+              "name": "ssh"
+            }
+          ],
+          "self": [
+            {
+              "href": "https://git.bbServerHost.info/projects/repoName/repos/repoName/browse"
+            }
+          ]
+        }
+      },
+      "project": {
+        "key": "~targetOwner",
+        "id": 2424,
+        "name": "some name",
+        "type": "PERSONAL",
+        "owner": {
+          "name": "owner",
+          "emailAddress": "owner@bbServerHost.com",
+          "active": true,
+          "displayName": "some name",
+          "id": 2198757,
+          "slug": "owner",
+          "type": "NORMAL",
+          "links": {
+            "self": [
+              {
+                "href": "https://git.bbServerHost.info/users/owner"
+              }
+            ]
+          }
+        },
+        "links": {
+          "self": [
+            {
+              "href": "https://git.bbServerHost.info/users/owner"
+            }
+          ]
+        }
+      },
+      "public": false,
+      "archived": false,
+      "links": {
+        "clone": [
+          {
+            "href": "ssh://git@git.bbServerHost.info/~owner/repoName.git",
+            "name": "ssh"
+          },
+          {
+            "href": "https://git.bbServerHost.info/scm/~owner/repoName.git",
+            "name": "http"
+          }
+        ],
+        "self": [
+          {
+            "href": "https://git.bbServerHost.info/users/owner/repos/repoName/browse"
+          }
+        ]
+      }
+    }
+  },
+  "locked": false,
+  "author": {
+    "user": {
+      "name": "owner",
+      "emailAddress": "owner@bbServerHost.com",
+      "active": true,
+      "displayName": "some name",
+      "id": 2114757,
+      "slug": "owner",
+      "type": "NORMAL",
+      "links": {
+        "self": [
+          {
+            "href": "https://git.bbServerHost.info/users/owner"
+          }
+        ]
+      }
+    },
+    "role": "AUTHOR",
+    "approved": false,
+    "status": "UNAPPROVED"
+  },
+  "reviewers": [],
+  "participants": [],
+  "links": {
+    "self": [
+      {
+        "href": "https://git.bbServerHost.info/users/owner/repos/repoName/pull-requests/6"
+      }
+    ]
+  }
+}

--- a/vcsclient/testdata/github/pull_request_info_response.json
+++ b/vcsclient/testdata/github/pull_request_info_response.json
@@ -220,7 +220,7 @@
       "name": "Hello-World",
       "full_name": "octocat/Hello-World",
       "owner": {
-        "login": "octocat",
+        "login": "jfrog",
         "id": 1,
         "node_id": "MDQ6VXNlcjE=",
         "avatar_url": "https://github.com/images/error/octocat_happy.gif",
@@ -362,7 +362,7 @@
       "name": "Hello-World",
       "full_name": "octocat/Hello-World",
       "owner": {
-        "login": "octocat",
+        "login": "jfrogForked",
         "id": 1,
         "node_id": "MDQ6VXNlcjE=",
         "avatar_url": "https://github.com/images/error/octocat_happy.gif",

--- a/vcsclient/testdata/github/pull_requests_list_response.json
+++ b/vcsclient/testdata/github/pull_requests_list_response.json
@@ -221,7 +221,7 @@
         "name": "Hello-World",
         "full_name": "octocat/Hello-World",
         "owner": {
-          "login": "octocat",
+          "login": "jfrog",
           "id": 1,
           "node_id": "MDQ6VXNlcjE=",
           "avatar_url": "https://github.com/images/error/octocat_happy.gif",
@@ -369,7 +369,7 @@
         "name": "Hello-World",
         "full_name": "octocat/Hello-World",
         "owner": {
-          "login": "octocat",
+          "login": "jfrog",
           "id": 1,
           "node_id": "MDQ6VXNlcjE=",
           "avatar_url": "https://github.com/images/error/octocat_happy.gif",

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -298,6 +298,7 @@ type PullRequestInfo struct {
 type BranchInfo struct {
 	Name       string
 	Repository string
+	Owner      string
 }
 
 // RepositoryInfo contains general information about repository.

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -332,17 +332,3 @@ func MapPullRequestState(state *PullRequestState) *string {
 	}
 	return &stateStringValue
 }
-
-func GetDefaultApiEndpoint(provider VcsProvider) string {
-	switch provider {
-	case GitHub:
-		return GitHubUrl
-	case GitLab:
-		return GitlabUrl
-	case AzureRepos:
-		return AzureUrl
-	default:
-		// Bitbucket server, for example, doesn't have a default as this is on perm
-		return ""
-	}
-}

--- a/vcsutils/utils.go
+++ b/vcsutils/utils.go
@@ -19,7 +19,12 @@ import (
 	"time"
 )
 
-const RemoteName = "origin"
+const (
+	RemoteName = "origin"
+	GitHubUrl  = "https://github.com"
+	GitlabUrl  = "https://gitlab.com"
+	AzureUrl   = "https://dev.azure.com"
+)
 
 // CreateToken create a random UUID
 func CreateToken() string {
@@ -326,4 +331,18 @@ func MapPullRequestState(state *PullRequestState) *string {
 		return nil
 	}
 	return &stateStringValue
+}
+
+func GetDefaultApiEndpoint(provider VcsProvider) string {
+	switch provider {
+	case GitHub:
+		return GitHubUrl
+	case GitLab:
+		return GitlabUrl
+	case AzureRepos:
+		return AzureUrl
+	default:
+		// Bitbucket server, for example, doesn't have a default as this is on perm
+		return ""
+	}
 }

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -278,3 +278,21 @@ func TestMapPullRequestState(t *testing.T) {
 		})
 	}
 }
+
+func TestGetDefaultApiEndpoint(t *testing.T) {
+	testCases := []struct {
+		expected    string
+		gitProvider VcsProvider
+	}{
+		{expected: GitHubUrl, gitProvider: GitHub},
+		{expected: GitlabUrl, gitProvider: GitLab},
+		{expected: "", gitProvider: BitbucketCloud},
+		{expected: "", gitProvider: BitbucketServer},
+		{expected: AzureUrl, gitProvider: AzureRepos},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf(tc.gitProvider.String()), func(t *testing.T) {
+			assert.Equal(t, tc.expected, GetDefaultApiEndpoint(tc.gitProvider))
+		})
+	}
+}

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -291,7 +291,7 @@ func TestGetDefaultApiEndpoint(t *testing.T) {
 		{expected: AzureUrl, gitProvider: AzureRepos},
 	}
 	for _, tc := range testCases {
-		t.Run(fmt.Sprintf(tc.gitProvider.String()), func(t *testing.T) {
+		t.Run(tc.gitProvider.String(), func(t *testing.T) {
 			assert.Equal(t, tc.expected, GetDefaultApiEndpoint(tc.gitProvider))
 		})
 	}

--- a/vcsutils/utils_test.go
+++ b/vcsutils/utils_test.go
@@ -278,21 +278,3 @@ func TestMapPullRequestState(t *testing.T) {
 		})
 	}
 }
-
-func TestGetDefaultApiEndpoint(t *testing.T) {
-	testCases := []struct {
-		expected    string
-		gitProvider VcsProvider
-	}{
-		{expected: GitHubUrl, gitProvider: GitHub},
-		{expected: GitlabUrl, gitProvider: GitLab},
-		{expected: "", gitProvider: BitbucketCloud},
-		{expected: "", gitProvider: BitbucketServer},
-		{expected: AzureUrl, gitProvider: AzureRepos},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.gitProvider.String(), func(t *testing.T) {
-			assert.Equal(t, tc.expected, GetDefaultApiEndpoint(tc.gitProvider))
-		})
-	}
-}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, and GitLab.

---

Add owner attribute to branch info, when getting pull request info it is important to know both of the owners, as they can differ when the pull request is from a forked repository.
