### PR TITLE
Fix wrong pull request branch parsing in Azure

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/jfrog/gofrog/datastructures"
 	"github.com/microsoft/azure-devops-go-api/azuredevops"
@@ -610,8 +611,8 @@ func (client *AzureReposClient) GetModifiedFiles(ctx context.Context, _, reposit
 
 func parsePullRequestDetails(client *AzureReposClient, pullRequest git.GitPullRequest, owner, repository string, withBody bool) PullRequestInfo {
 	// Trim the branches prefix and get the actual branches name
-	shortSourceName := (*pullRequest.SourceRefName)[strings.LastIndex(*pullRequest.SourceRefName, "/")+1:]
-	shortTargetName := (*pullRequest.TargetRefName)[strings.LastIndex(*pullRequest.TargetRefName, "/")+1:]
+	shortSourceName := plumbing.ReferenceName(*pullRequest.SourceRefName).Short()
+	shortTargetName := plumbing.ReferenceName(*pullRequest.TargetRefName).Short()
 
 	var prBody string
 	bodyPtr := pullRequest.Description

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -221,6 +221,8 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 
 	// Test with body
 	prBody := "hello world"
+	branch1WithPrefix := "refs/heads/" + branch1
+	branch2WithPrefix := "refs/heads/" + branch2
 	res = ListOpenPullRequestsResponse{
 		Value: []git.GitPullRequest{
 			{
@@ -228,8 +230,8 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 				Description:   &prBody,
 				Url:           &url,
 				Repository:    &git.GitRepository{Name: &repo1},
-				SourceRefName: &branch1,
-				TargetRefName: &branch2,
+				SourceRefName: &branch1WithPrefix,
+				TargetRefName: &branch2WithPrefix,
 			},
 		},
 		Count: 1,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature.

---
- When fetching the pull request details, we removed all the keywords with slashes from the branch names, instead of only removing the prefixes within the Git 'refs' namespace.
- Fixes https://github.com/jfrog/frogbot/issues/446
