### PR TITLE
Implement GetRepositoryInfo for AzureDevops

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -421,13 +421,10 @@ func (client *AzureReposClient) GetRepositoryInfo(ctx context.Context, project, 
 }
 
 func getAzureDevOpsVisibility(visibility core.ProjectVisibility) RepositoryVisibility {
-	switch visibility {
-	case "private":
+	if visibility == "private" {
 		return Private
-	case "public":
-		return Public
 	}
-	return Private
+	return Public
 }
 
 // GetCommitBySha on Azure Repos

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -749,3 +749,8 @@ func createBadAzureReposClient(t *testing.T, response []byte) (VcsClient, func()
 		createAzureReposHandler)
 	return client, cleanUp
 }
+
+func TestAzureReposClient_getAzureDevOpsVisibility(t *testing.T) {
+	assert.Equal(t, Public, getAzureDevOpsVisibility("public"))
+	assert.Equal(t, Private, getAzureDevOpsVisibility("private"))
+}

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -467,6 +467,11 @@ func TestAzureReposClient_GetRepositoryInfo(t *testing.T) {
 		RepositoryVisibility: 2,
 	}, repo)
 	assert.NoError(t, err)
+
+	badClient, cleanUp := createBadAzureReposClient(t, []byte{})
+	defer cleanUp()
+	_, err = badClient.GetRepositoryInfo(ctx, "project", "test")
+	assert.Error(t, err)
 }
 
 func TestAzureReposClient_GetCommitBySha(t *testing.T) {

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -451,10 +451,22 @@ func TestAzureReposClient_CreateLabel(t *testing.T) {
 
 func TestAzureReposClient_GetRepositoryInfo(t *testing.T) {
 	ctx := context.Background()
-	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, "", "unsupportedTest", createAzureReposHandler)
+	// listRepositories and GetRepositoryInfo has the same location ID in azuredevops
+	expectedUri := "listRepositories"
+	response, err := os.ReadFile(filepath.Join("testdata", "azurerepos", "repositoryInfo.json"))
+	assert.NoError(t, err)
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, response, expectedUri, createAzureReposHandler)
 	defer cleanUp()
-	_, err := client.GetRepositoryInfo(ctx, owner, repo1)
-	assert.Error(t, err)
+	repo, err := client.GetRepositoryInfo(ctx, owner, repo1)
+	assert.NoError(t, err)
+	assert.Equal(t, RepositoryInfo{
+		CloneInfo: CloneInfo{
+			HTTP: "https://dev.azure.com/fabrikam/FabrikamCloud/_git/FabrikamCloud",
+			SSH:  "ssh://dev.azure.com/fabrikam/_apis/projects/3b3ae425-0079-421f-9101-bcf15d6df041",
+		},
+		RepositoryVisibility: 2,
+	}, repo)
+	assert.NoError(t, err)
 }
 
 func TestAzureReposClient_GetCommitBySha(t *testing.T) {

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -826,7 +826,7 @@ func getGitHubWebhookEvents(webhookEvents ...vcsutils.WebhookEvent) []string {
 
 func getGitHubRepositoryVisibility(repo *github.Repository) RepositoryVisibility {
 	if repo == nil || repo.Visibility == nil {
-		// Return default value private is this is most restricted visibility
+		// Return default value private as this is most restricted visibility.
 		return Private
 	}
 	switch *repo.Visibility {

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -825,6 +825,10 @@ func getGitHubWebhookEvents(webhookEvents ...vcsutils.WebhookEvent) []string {
 }
 
 func getGitHubRepositoryVisibility(repo *github.Repository) RepositoryVisibility {
+	if repo == nil || repo.Visibility == nil {
+		// Return default value private is this is most restricted visibility
+		return Private
+	}
 	switch *repo.Visibility {
 	case "public":
 		return Public

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -182,6 +182,7 @@ func TestGitHubClient_getRepositoryVisibility(t *testing.T) {
 	assert.Equal(t, Internal, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))
 	visibility = "private"
 	assert.Equal(t, Private, getGitHubRepositoryVisibility(&github.Repository{Visibility: &visibility}))
+	assert.Equal(t, Private, getGitHubRepositoryVisibility(&github.Repository{}))
 }
 
 func TestGitHubClient_getGitHubCommitState(t *testing.T) {

--- a/vcsclient/testdata/azurerepos/repositoryInfo.json
+++ b/vcsclient/testdata/azurerepos/repositoryInfo.json
@@ -1,0 +1,15 @@
+{
+  "id": "2f3d611a-f012-4b39-b157-8db63f380226",
+  "name": "FabrikamCloud",
+  "url": "https://dev.azure.com/fabrikam/_apis/git/repositories/2f3d611a-f012-4b39-b157-8db63f380226",
+  "project": {
+    "id": "3b3ae425-0079-421f-9101-bcf15d6df041",
+    "name": "FabrikamCloud",
+    "url": "https://dev.azure.com/fabrikam/_apis/projects/3b3ae425-0079-421f-9101-bcf15d6df041",
+    "state": "",
+    "revision": 411518573,
+    "visibility": "private"
+  },
+  "remoteUrl": "https://dev.azure.com/fabrikam/FabrikamCloud/_git/FabrikamCloud",
+  "sshUrl": "ssh://dev.azure.com/fabrikam/_apis/projects/3b3ae425-0079-421f-9101-bcf15d6df041"
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature. already exists

---

Add implementation for GetRepositoryInfo in azure DevOps.
