### PR TITLE
Fix BitBucket CommitInfo Url

### DIFF
--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -752,7 +752,7 @@ func (client *BitbucketServerClient) mapBitbucketServerCommitToCommitInfo(commit
 	for i, p := range commit.Parents {
 		parents[i] = p.ID
 	}
-	url := fmt.Sprintf("%s/api/1.0/projects/%s/repos/%s/commits/%s",
+	url := fmt.Sprintf("%s/projects/%s/repos/%s/commits/%s",
 		client.vcsInfo.APIEndpoint, owner, repo, commit.ID)
 	return CommitInfo{
 		Hash:          commit.ID,

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -753,7 +753,7 @@ func (client *BitbucketServerClient) mapBitbucketServerCommitToCommitInfo(commit
 		parents[i] = p.ID
 	}
 	url := fmt.Sprintf("%s/projects/%s/repos/%s/commits/%s",
-		client.vcsInfo.APIEndpoint, owner, repo, commit.ID)
+		strings.TrimSuffix(client.vcsInfo.APIEndpoint, "/rest"), owner, repo, commit.ID)
 	return CommitInfo{
 		Hash:          commit.ID,
 		AuthorName:    commit.Author.Name,

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -333,7 +333,7 @@ func TestBitbucketServer_GetLatestCommit(t *testing.T) {
 	result, err := client.GetLatestCommit(ctx, owner, repo1, "master")
 
 	assert.NoError(t, err)
-	expectedUrl := fmt.Sprintf("%s/rest/api/1.0/projects/jfrog/repos/repo-1"+
+	expectedUrl := fmt.Sprintf("%s/projects/jfrog/repos/repo-1"+
 		"/commits/def0123abcdef4567abcdef8987abcdef6543abc", serverUrl)
 	assert.Equal(t, CommitInfo{
 		Hash:          "def0123abcdef4567abcdef8987abcdef6543abc",
@@ -364,7 +364,7 @@ func TestBitbucketServer_GetCommits(t *testing.T) {
 	result, err := client.GetCommits(ctx, owner, repo1, "master")
 
 	assert.NoError(t, err)
-	expectedUrl := fmt.Sprintf("%s/rest/api/1.0/projects/jfrog/repos/repo-1"+
+	expectedUrl := fmt.Sprintf("%s/projects/jfrog/repos/repo-1"+
 		"/commits/def0123abcdef4567abcdef8987abcdef6543abc", serverUrl)
 	assert.Equal(t, CommitInfo{
 		Hash:          "def0123abcdef4567abcdef8987abcdef6543abc",
@@ -596,7 +596,7 @@ func TestBitbucketServer_GetCommitBySha(t *testing.T) {
 	result, err := client.GetCommitBySha(ctx, owner, repo1, sha)
 
 	assert.NoError(t, err)
-	expectedUrl := fmt.Sprintf("%s/rest/api/1.0/projects/jfrog/repos/repo-1"+
+	expectedUrl := fmt.Sprintf("%s/projects/jfrog/repos/repo-1"+
 		"/commits/abcdef0123abcdef4567abcdef8987abcdef6543", serverUrl)
 	assert.Equal(t, CommitInfo{
 		Hash:          sha,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature.

---

For BitBucket, return the actual URL of the commit instead of the rest API URL for this commit
