### PR TITLE
GitLab - Corrected "Closed" status value in UpdatePullRequest

### DIFF
--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -834,7 +834,7 @@ func mapGitLabPullRequestState(state *vcsutils.PullRequestState) *string {
 	case vcsutils.Open:
 		stateStringValue = "reopen"
 	case vcsutils.Closed:
-		stateStringValue = "closed"
+		stateStringValue = "close"
 	default:
 		return nil
 	}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature.

---
- Updated the close merge request value in UpdatePullRequest to "close" instead of "closed".