### PR TITLE
Get method for size limitation on PR content

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -19,7 +19,11 @@ import (
 	"time"
 )
 
-const defaultAzureBaseUrl = "https://dev.azure.com/"
+const (
+	defaultAzureBaseUrl              = "https://dev.azure.com/"
+	azurePullRequestDetailsSizeLimit = 4000
+	azurePullRequestCommentSizeLimit = 150000
+)
 
 // Azure Devops API version 6
 type AzureReposClient struct {
@@ -156,6 +160,14 @@ func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, rep
 	}
 	client.logger.Info(repository, vcsutils.SuccessfulRepoDownload)
 	return
+}
+
+func (client *AzureReposClient) GetPullRequestCommentSizeLimit() int {
+	return azurePullRequestCommentSizeLimit
+}
+
+func (client *AzureReposClient) GetPullRequestDetailsSizeLimit() int {
+	return azurePullRequestDetailsSizeLimit
 }
 
 // CreatePullRequest on Azure Repos

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -282,6 +282,14 @@ func (client *BitbucketCloudClient) DownloadRepository(ctx context.Context, owne
 	return vcsutils.CreateDotGitFolderWithRemote(localPath, "origin", repositoryInfo.CloneInfo.HTTP)
 }
 
+func (client *BitbucketCloudClient) GetPullRequestCommentSizeLimit() int {
+	return bitbucketPrContentSizeLimit
+}
+
+func (client *BitbucketCloudClient) GetPullRequestDetailsSizeLimit() int {
+	return bitbucketPrContentSizeLimit
+}
+
 // CreatePullRequest on Bitbucket cloud
 func (client *BitbucketCloudClient) CreatePullRequest(ctx context.Context, owner, repository, sourceBranch,
 	targetBranch, title, description string) error {

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -7,7 +7,10 @@ import (
 	"time"
 )
 
-const notSupportedOnBitbucket = "currently not supported on Bitbucket"
+const (
+	notSupportedOnBitbucket     = "currently not supported on Bitbucket"
+	bitbucketPrContentSizeLimit = 32768
+)
 
 var (
 	errLabelsNotSupported                                 = fmt.Errorf("labels are %s", notSupportedOnBitbucket)

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -277,6 +277,14 @@ func (client *BitbucketServerClient) DownloadRepository(ctx context.Context, own
 		repositoryInfo.CloneInfo.HTTP)
 }
 
+func (client *BitbucketServerClient) GetPullRequestCommentSizeLimit() int {
+	return bitbucketPrContentSizeLimit
+}
+
+func (client *BitbucketServerClient) GetPullRequestDetailsSizeLimit() int {
+	return bitbucketPrContentSizeLimit
+}
+
 // CreatePullRequest on Bitbucket server
 func (client *BitbucketServerClient) CreatePullRequest(ctx context.Context, owner, repository, sourceBranch, targetBranch,
 	title, description string) error {

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -24,6 +24,8 @@ import (
 const (
 	maxRetries               = 5
 	retriesIntervalMilliSecs = 60000
+	// https://github.com/orgs/community/discussions/27190
+	githubPrContentSizeLimit = 65536
 )
 
 var rateLimitRetryStatuses = []int{http.StatusForbidden, http.StatusTooManyRequests}
@@ -319,6 +321,14 @@ func executeDownloadArchiveFromLink(baseURL string) (*http.Response, error) {
 		return httpResponse, err
 	}
 	return httpResponse, vcsutils.CheckResponseStatusWithBody(httpResponse, http.StatusOK)
+}
+
+func (client *GitHubClient) GetPullRequestCommentSizeLimit() int {
+	return githubPrContentSizeLimit
+}
+
+func (client *GitHubClient) GetPullRequestDetailsSizeLimit() int {
+	return githubPrContentSizeLimit
 }
 
 // CreatePullRequest on GitHub

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -225,6 +225,14 @@ func (client *GitLabClient) DownloadRepository(ctx context.Context, owner, repos
 	return vcsutils.CreateDotGitFolderWithRemote(localPath, vcsutils.RemoteName, repositoryInfo.CloneInfo.HTTP)
 }
 
+func (client *GitLabClient) GetPullRequestCommentSizeLimit() int {
+	return gitlabMergeRequestCommentSizeLimit
+}
+
+func (client *GitLabClient) GetPullRequestDetailsSizeLimit() int {
+	return gitlabMergeRequestDetailsSizeLimit
+}
+
 // CreatePullRequest on GitLab
 func (client *GitLabClient) CreatePullRequest(ctx context.Context, owner, repository, sourceBranch, targetBranch,
 	title, description string) error {

--- a/vcsclient/gitlabcommon.go
+++ b/vcsclient/gitlabcommon.go
@@ -6,3 +6,10 @@ import (
 
 var errGitLabCodeScanningNotSupported = errors.New("code scanning is not supported on Gitlab")
 var errGitLabGetRepoEnvironmentInfoNotSupported = errors.New("get repository environment info is currently not supported on Bitbucket")
+
+const (
+	// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr
+	gitlabMergeRequestDetailsSizeLimit = 1048576
+	// https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note
+	gitlabMergeRequestCommentSizeLimit = 1000000
+)

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -295,6 +295,12 @@ type VcsClient interface {
 	// refBefore     - A VCS reference: commit SHA, branch name, tag name
 	// refAfter      - A VCS reference: commit SHA, branch name, tag name
 	GetModifiedFiles(ctx context.Context, owner, repository, refBefore, refAfter string) ([]string, error)
+
+	// GetPullRequestCommentSizeLimit returns the maximum size of a pull request comment
+	GetPullRequestCommentSizeLimit() int
+
+	// GetPullRequestDetailsSizeLimit returns the maximum size of a pull request details
+	GetPullRequestDetailsSizeLimit() int
 }
 
 // CommitInfo contains the details of a commit


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature.

---

Add new methods to get the size limitations for the pull request content (details/comments).
It allows us to figure out dynamically if the content will overflow and the API will result in failures.

## Limitations found:
### Github
* Size limitation: `65,536` chars
Limitation is not mentioned in the docs, found references at: https://github.com/orgs/community/discussions/27190
### Gitlab
* Merge Request details limit: `1,048,576` chars [docs](https://docs.gitlab.com/ee/api/merge_requests.html#create-mr)
* Merge Request comment content limit: `1,000,000` chars [docs](https://docs.gitlab.com/ee/api/notes.html#create-new-merge-request-note)
### BitBucket
* Pull Request content limit: `32,768` chars:
```
11:07:00 [Error] couldn't add pull request comment: Status: 400 Bad Request, Body: {"errors":[{"context":"text","message":"Please enter a non-empty value less than 32768 characters","exceptionName":null}]}
```
### Azure Repos
* Pull Request details limit: `4,000` chars
![image](https://github.com/jfrog/froggit-go/assets/49212512/0aa94bff-5569-4128-8f0b-2e0894a675a5)
Limitation is not mentioned in the docs, found references at: https://developercommunity.visualstudio.com/t/Raise-the-character-limit-for-pull-reque/365708?stateGroup=active
* Pull Request comment content limit: `150,000` chars 
Limitation is not mentioned in the docs, found references at: https://github.com/Azure/AzOps/issues/652