### PR TITLE
Add 'Title' attribute to PR information

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -720,13 +720,9 @@ func parsePullRequestDetails(client *AzureReposClient, pullRequest git.GitPullRe
 			client.logger.Warn(vcsutils.FailedForkedRepositoryExtraction)
 		}
 	}
-	var prTitle string
-	if pullRequest.Title != nil {
-		prTitle = *pullRequest.Title
-	}
 	return PullRequestInfo{
 		ID:    int64(*pullRequest.PullRequestId),
-		Title: prTitle,
+		Title: vcsutils.DefaultIfNotNil(pullRequest.Title),
 		Body:  prBody,
 		URL:   vcsutils.DefaultIfNotNil(pullRequest.Url),
 		Source: BranchInfo{

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -720,10 +720,13 @@ func parsePullRequestDetails(client *AzureReposClient, pullRequest git.GitPullRe
 			client.logger.Warn(vcsutils.FailedForkedRepositoryExtraction)
 		}
 	}
-
+	var prTitle string
+	if pullRequest.Title != nil {
+		prTitle = *pullRequest.Title
+	}
 	return PullRequestInfo{
 		ID:    int64(*pullRequest.PullRequestId),
-		Title: *pullRequest.Title,
+		Title: prTitle,
 		Body:  prBody,
 		URL:   vcsutils.DefaultIfNotNil(pullRequest.Url),
 		Source: BranchInfo{

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -722,9 +722,10 @@ func parsePullRequestDetails(client *AzureReposClient, pullRequest git.GitPullRe
 	}
 
 	return PullRequestInfo{
-		ID:   int64(*pullRequest.PullRequestId),
-		Body: prBody,
-		URL:  vcsutils.DefaultIfNotNil(pullRequest.Url),
+		ID:    int64(*pullRequest.PullRequestId),
+		Title: *pullRequest.Title,
+		Body:  prBody,
+		URL:   vcsutils.DefaultIfNotNil(pullRequest.Url),
 		Source: BranchInfo{
 			Name:       shortSourceName,
 			Repository: repository,

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -721,10 +721,10 @@ func parsePullRequestDetails(client *AzureReposClient, pullRequest git.GitPullRe
 		}
 	}
 	return PullRequestInfo{
-		ID:      int64(*pullRequest.PullRequestId),
-		Title: vcsutils.DefaultIfNotNil(pullRequest.Title),
-		Body:    prBody,
-		URL:     vcsutils.DefaultIfNotNil(pullRequest.Url),
+		ID:     int64(*pullRequest.PullRequestId),
+		Title:  vcsutils.DefaultIfNotNil(pullRequest.Title),
+		Body:   prBody,
+		URL:    vcsutils.DefaultIfNotNil(pullRequest.Url),
 		Author: vcsutils.DefaultIfNotNil(pullRequest.CreatedBy.DisplayName),
 		Source: BranchInfo{
 			Name:       shortSourceName,

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -343,7 +343,9 @@ func TestAzureReposClient_GetPullRequest(t *testing.T) {
 	forkedSourceUrl := fmt.Sprintf("https://dev.azure.com/%s/201f2c7f-305a-446c-a1d6-a04ec811093b/_apis/git/repositories/82d33a66-8971-4279-9687-19c69e66e114", forkedOwner)
 	url := "https://dev.azure.com/owner/project/_git/repo/pullrequest/47"
 	author := "user"
+	title := "PR title"
 	res := git.GitPullRequest{
+		Title:         &title,
 		SourceRefName: &sourceName,
 		TargetRefName: &targetName,
 		PullRequestId: &pullRequestId,
@@ -368,6 +370,7 @@ func TestAzureReposClient_GetPullRequest(t *testing.T) {
 		Target: BranchInfo{Name: targetName, Repository: repoName, Owner: owner},
 		URL:    url,
 		Author: author,
+		Title:  title,
 	})
 
 	// Fail source repository owner extraction, should be empty string and not fail the process.

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -246,11 +246,13 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 		Count int
 	}
 	pullRequestId := 1
+	testTitle := "test-title"
 	url := "https://dev.azure.com/owner/project/_git/repo/pullrequest/47"
 	res := ListOpenPullRequestsResponse{
 		Value: []git.GitPullRequest{
 			{
 				PullRequestId: &pullRequestId,
+				Title:         &testTitle,
 				Repository:    &git.GitRepository{Name: &repo1},
 				SourceRefName: &branch1,
 				TargetRefName: &branch2,
@@ -269,6 +271,7 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 	assert.EqualValues(t, pullRequestsInfo, []PullRequestInfo{
 		{
 			ID:     1,
+			Title:  testTitle,
 			Source: BranchInfo{Name: branch1, Repository: repo1},
 			Target: BranchInfo{Name: branch2, Repository: repo1},
 			URL:    url,
@@ -288,6 +291,7 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 		Value: []git.GitPullRequest{
 			{
 				PullRequestId: &pullRequestId,
+				Title:         &testTitle,
 				Description:   &prBody,
 				Url:           &url,
 				Repository:    &git.GitRepository{Name: &repo1},
@@ -307,6 +311,7 @@ func TestAzureRepos_TestListOpenPullRequests(t *testing.T) {
 	assert.EqualValues(t, pullRequestsInfo, []PullRequestInfo{
 		{
 			ID:     1,
+			Title:  testTitle,
 			Body:   prBody,
 			Source: BranchInfo{Name: branch1, Repository: repo1},
 			Target: BranchInfo{Name: branch2, Repository: repo1},

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -661,6 +661,7 @@ type pullRequestsResponse struct {
 
 type pullRequestsDetails struct {
 	ID     int64             `json:"id"`
+	Title  string            `json:"title"`
 	Body   string            `json:"description"`
 	Source pullRequestBranch `json:"source"`
 	Target pullRequestBranch `json:"destination"`
@@ -807,8 +808,9 @@ func mapBitbucketCloudPullRequestToPullRequestInfo(parsedPullRequests *pullReque
 			body = pullRequest.Body
 		}
 		pullRequests[i] = PullRequestInfo{
-			ID:   pullRequest.ID,
-			Body: body,
+			ID:    pullRequest.ID,
+			Title: pullRequest.Title,
+			Body:  body,
 			Source: BranchInfo{
 				Name:       pullRequest.Source.Name.Str,
 				Repository: pullRequest.Source.Repository.Name,

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -814,9 +814,9 @@ func mapBitbucketCloudPullRequestToPullRequestInfo(parsedPullRequests *pullReque
 			body = pullRequest.Body
 		}
 		pullRequests[i] = PullRequestInfo{
-			ID:      pullRequest.ID,
-			Title: pullRequest.Title,
-			Body:    body,
+			ID:     pullRequest.ID,
+			Title:  pullRequest.Title,
+			Body:   body,
 			Author: pullRequest.Author.DisplayName,
 			Source: BranchInfo{
 				Name:       pullRequest.Source.Name.Str,

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -386,6 +386,7 @@ func (client *BitbucketCloudClient) GetPullRequestByID(ctx context.Context, owne
 
 	pullRequestInfo = PullRequestInfo{
 		ID:     pullRequestDetails.ID,
+		Title:  pullRequestDetails.Title,
 		Author: pullRequestDetails.Author.DisplayName,
 		Source: BranchInfo{
 			Name:       pullRequestDetails.Source.Name.Str,

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -175,6 +175,7 @@ func TestBitbucketCloud_ListOpenPullRequests(t *testing.T) {
 	assert.Len(t, result, 3)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     3,
+		Title:  "A change",
 		Source: BranchInfo{Name: "test-2", Repository: "user17/test"},
 		Target: BranchInfo{Name: "master", Repository: "user17/test"},
 	}, result[0])
@@ -186,6 +187,7 @@ func TestBitbucketCloud_ListOpenPullRequests(t *testing.T) {
 	assert.Len(t, result, 3)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     3,
+		Title:  "A change",
 		Body:   "hello world",
 		Source: BranchInfo{Name: "test-2", Repository: "user17/test"},
 		Target: BranchInfo{Name: "master", Repository: "user17/test"},

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -211,6 +211,7 @@ func TestBitbucketCloudClient_GetPullRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     int64(pullRequestId),
+		Title:  "s",
 		Author: "fname lname",
 		Source: BranchInfo{Name: "pr", Repository: "froggit", Owner: "forkedWorkspace"},
 		Target: BranchInfo{Name: "main", Repository: "froggit", Owner: "workspace"},

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -401,6 +401,7 @@ func mapBitbucketServerPullRequestToPullRequestInfo(pullRequest bitbucketv1.Pull
 	}
 	return PullRequestInfo{
 		ID:     int64(pullRequest.ID),
+		Title:  pullRequest.Title,
 		Source: BranchInfo{Name: pullRequest.FromRef.DisplayID, Repository: pullRequest.ToRef.Repository.Slug, Owner: sourceOwner},
 		Target: BranchInfo{Name: pullRequest.ToRef.DisplayID, Repository: pullRequest.ToRef.Repository.Slug, Owner: owner},
 		Body:   body,

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -235,6 +235,7 @@ func TestBitbucketServer_ListOpenPullRequests(t *testing.T) {
 	assert.Len(t, result, 1)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     101,
+		Title:  "Talking Nerdy",
 		Source: BranchInfo{Name: "feature-ABC-123", Repository: repo1, Owner: forkedOwner},
 		Target: BranchInfo{Name: "master", Repository: repo1, Owner: owner},
 		URL:    "https://link/to/pullrequest",
@@ -247,6 +248,7 @@ func TestBitbucketServer_ListOpenPullRequests(t *testing.T) {
 	assert.Len(t, result, 1)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     101,
+		Title:  "Talking Nerdy",
 		Body:   "hello world",
 		Source: BranchInfo{Name: "feature-ABC-123", Repository: repo1, Owner: forkedOwner},
 		Target: BranchInfo{Name: "master", Repository: repo1, Owner: owner},
@@ -268,6 +270,7 @@ func TestBitbucketServerClient_GetPullRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     int64(pullRequestId),
+		Title:  "New vul 2",
 		Source: BranchInfo{Name: "new_vul_2", Repository: "repoName", Owner: "~fromOwner"},
 		Target: BranchInfo{Name: "master", Repository: "repoName", Owner: owner},
 		URL:    "https://git.bbServerHost.info/users/owner/repos/repoName/pull-requests/6",

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -456,10 +456,10 @@ func mapGitHubPullRequestToPullRequestInfo(ghPullRequest *github.PullRequest, wi
 	}
 
 	return PullRequestInfo{
-		ID:      int64(vcsutils.DefaultIfNotNil(ghPullRequest.Number)),
-		Title: vcsutils.DefaultIfNotNil(ghPullRequest.Title),
-		URL:     vcsutils.DefaultIfNotNil(ghPullRequest.HTMLURL),
-		Body:    body,
+		ID:     int64(vcsutils.DefaultIfNotNil(ghPullRequest.Number)),
+		Title:  vcsutils.DefaultIfNotNil(ghPullRequest.Title),
+		URL:    vcsutils.DefaultIfNotNil(ghPullRequest.HTMLURL),
+		Body:   body,
 		Author: vcsutils.DefaultIfNotNil(ghPullRequest.User.Login),
 		Source: BranchInfo{
 			Name:       sourceBranch,

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -456,9 +456,10 @@ func mapGitHubPullRequestToPullRequestInfo(ghPullRequest *github.PullRequest, wi
 	}
 
 	return PullRequestInfo{
-		ID:   int64(vcsutils.DefaultIfNotNil(ghPullRequest.Number)),
-		URL:  vcsutils.DefaultIfNotNil(ghPullRequest.HTMLURL),
-		Body: body,
+		ID:    int64(vcsutils.DefaultIfNotNil(ghPullRequest.Number)),
+		Title: *ghPullRequest.Title,
+		URL:   vcsutils.DefaultIfNotNil(ghPullRequest.HTMLURL),
+		Body:  body,
 		Source: BranchInfo{
 			Name:       sourceBranch,
 			Repository: sourceRepoName,

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -457,7 +457,7 @@ func mapGitHubPullRequestToPullRequestInfo(ghPullRequest *github.PullRequest, wi
 
 	return PullRequestInfo{
 		ID:    int64(vcsutils.DefaultIfNotNil(ghPullRequest.Number)),
-		Title: *ghPullRequest.Title,
+		Title: vcsutils.DefaultIfNotNil(ghPullRequest.Title),
 		URL:   vcsutils.DefaultIfNotNil(ghPullRequest.HTMLURL),
 		Body:  body,
 		Source: BranchInfo{

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -669,6 +669,7 @@ func TestGitHubClient_ListOpenPullRequests(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     1347,
+		Title:  "Amazing new feature",
 		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: owner},
 		URL:    "https://github.com/octocat/Hello-World/pull/1347",
@@ -684,6 +685,7 @@ func TestGitHubClient_ListOpenPullRequests(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     1347,
+		Title:  "Amazing new feature",
 		Body:   "hello world",
 		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: owner},

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -713,6 +713,7 @@ func TestGitHubClient_GetPullRequestByID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     int64(pullRequestId),
+		Title:  "Amazing new feature",
 		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: forkedOwner},
 		URL:    "https://github.com/octocat/Hello-World/pull/1347",

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -832,8 +832,9 @@ func (client *GitLabClient) mapGitLabMergeRequestToPullRequestInfo(mergeRequest 
 	}
 
 	return PullRequestInfo{
-		ID:   int64(mergeRequest.IID),
-		Body: body,
+		ID:    int64(mergeRequest.IID),
+		Title: mergeRequest.Title,
+		Body:  body,
 		Source: BranchInfo{
 			Name:       mergeRequest.SourceBranch,
 			Repository: repository,

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -832,9 +832,9 @@ func (client *GitLabClient) mapGitLabMergeRequestToPullRequestInfo(mergeRequest 
 	}
 
 	return PullRequestInfo{
-		ID:      int64(mergeRequest.IID),
-		Title: mergeRequest.Title,
-		Body:    body,
+		ID:     int64(mergeRequest.IID),
+		Title:  mergeRequest.Title,
+		Body:   body,
 		Author: mergeRequest.Author.Username,
 		Source: BranchInfo{
 			Name:       mergeRequest.SourceBranch,

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -322,6 +322,7 @@ func TestGitLabClient_GetPullRequestByID(t *testing.T) {
 	assert.NoError(t, err)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     133,
+		Title:  "Manual job rules",
 		Source: BranchInfo{Name: "manual-job-rules", Repository: repoName, Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: repoName, Owner: owner},
 		URL:    "https://gitlab.com/marcel.amirault/test-project/-/merge_requests/133",

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -287,6 +287,7 @@ func TestGitLabClient_ListOpenPullRequests(t *testing.T) {
 	assert.Len(t, result, 1)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     302,
+		Title:  "test1",
 		Source: BranchInfo{Name: "test1", Repository: repo1, Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: repo1, Owner: owner},
 		URL:    "https://gitlab.example.com/my-group/my-project/merge_requests/1",
@@ -298,6 +299,7 @@ func TestGitLabClient_ListOpenPullRequests(t *testing.T) {
 	assert.Len(t, result, 1)
 	assert.EqualValues(t, PullRequestInfo{
 		ID:     302,
+		Title:  "test1",
 		Body:   "hello world",
 		Source: BranchInfo{Name: "test1", Repository: repo1, Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: repo1, Owner: owner},

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -339,6 +339,7 @@ type CommentInfo struct {
 
 type PullRequestInfo struct {
 	ID     int64
+	Title  string
 	Body   string
 	URL    string
 	Source BranchInfo


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [ ] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [ ] I added the relevant documentation for the new feature.

---

Adding 'Title' attribute to the response that returns when asking to get a PR/MR info