### PR TITLE
Added create PR with detailed data returned to the func

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
       - [Create Or Update Environment](#create-or-update-environment)
       - [CommitAndPushFiles](#commit-and-push-files)
       - [Merge Pull Request](#merge-pull-request)
+      - [Create Pull Request Detailed](#create-pull-request-detailed)
     - [Webhook Parser](#webhook-parser)
 
 ### VCS Clients
@@ -991,6 +992,30 @@ commitMessage := "example commit message"
 
 // Merge the pull request
 err = client.MergePullRequest(ctx, owner, repo, prNumber, commitMessage)
+```
+
+#### Create Pull Request Detailed
+
+Notice - Create Pull Request Detailed is currently supported on GitHub only.
+
+```go
+// Go context
+ctx := context.Background()
+// Organization or username
+owner := "jfrog"
+// VCS repository
+repository := "jfrog-cli"
+// Source pull request branch
+sourceBranch := "dev"
+// Target pull request branch
+targetBranch := "main"
+// Pull request title
+title := "Pull request title"
+// Pull request description
+description := "Pull request description"
+
+// Creates a pull request and returns its number and URL.
+prInfo,err := client.CreatePullRequestDetailed(ctx, owner, repository, sourceBranch, targetBranch, title, description)
 ```
 
 ### Webhook Parser

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -770,6 +770,10 @@ func (client *AzureReposClient) MergePullRequest(ctx context.Context, owner, rep
 	return getUnsupportedInAzureError("merge pull request")
 }
 
+func (client *AzureReposClient) CreatePullRequestDetailed(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) (CreatedPullRequestInfo, error) {
+	return CreatedPullRequestInfo{}, getUnsupportedInAzureError("create pull request detailed")
+}
+
 func parsePullRequestDetails(client *AzureReposClient, pullRequest git.GitPullRequest, owner, repository string, withBody bool) PullRequestInfo {
 	// Trim the branches prefix and get the actual branches name
 	shortSourceName := plumbing.ReferenceName(*pullRequest.SourceRefName).Short()

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -730,6 +730,10 @@ func (client *BitbucketCloudClient) MergePullRequest(ctx context.Context, owner,
 	return errBitbucketMergePullRequestNotSupported
 }
 
+func (client *BitbucketCloudClient) CreatePullRequestDetailed(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) (CreatedPullRequestInfo, error) {
+	return CreatedPullRequestInfo{}, errBitbucketCreatePullRequestDetailedNotSupported
+}
+
 type pullRequestsResponse struct {
 	Values []pullRequestsDetails `json:"values"`
 }

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -32,6 +32,7 @@ var (
 	errBitbucketGetRepoTeamsByPermissionsNotSupported        = fmt.Errorf("get repo teams by permissions is %s", notSupportedOnBitbucket)
 	errBitbucketCreateOrUpdateEnvironmentNotSupported        = fmt.Errorf("create or update environment is %s", notSupportedOnBitbucket)
 	errBitbucketMergePullRequestNotSupported                 = fmt.Errorf("merge pull request is %s", notSupportedOnBitbucket)
+	errBitbucketCreatePullRequestDetailedNotSupported        = fmt.Errorf("creating pull request detailed is %s", notSupportedOnBitbucket)
 )
 
 type BitbucketCommitInfo struct {

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -921,6 +921,10 @@ func (client *BitbucketServerClient) MergePullRequest(ctx context.Context, owner
 	return errBitbucketMergePullRequestNotSupported
 }
 
+func (client *BitbucketServerClient) CreatePullRequestDetailed(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) (CreatedPullRequestInfo, error) {
+	return CreatedPullRequestInfo{}, errBitbucketCreatePullRequestDetailedNotSupported
+}
+
 func getBitbucketServerRepositoryVisibility(public bool) RepositoryVisibility {
 	if public {
 		return Public

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1203,6 +1203,22 @@ func TestGitHubClient_MergePullRequest(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGitHubClient_CreatePullRequestDetailed(t *testing.T) {
+	ctx := context.Background()
+	expectedURL := "https://github.com/jfrog/repo1/pull/875"
+	expectedPrNumber := 1234
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, github.PullRequest{Number: github.Int(expectedPrNumber), HTMLURL: github.String(expectedURL)}, "/repos/jfrog/repo-1/pulls", createGitHubHandler)
+	defer cleanUp()
+
+	prInfo, err := client.CreatePullRequestDetailed(ctx, owner, repo1, branch1, branch2, "PR title", "PR body")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPrNumber, prInfo.Number)
+	assert.Equal(t, expectedURL, prInfo.URL)
+
+	prInfo, err = createBadGitHubClient(t).CreatePullRequestDetailed(ctx, owner, repo1, branch1, branch2, "PR title", "PR body")
+	assert.Error(t, err)
+}
+
 func createBadGitHubClient(t *testing.T) VcsClient {
 	client, err := NewClientBuilder(vcsutils.GitHub).ApiEndpoint("https://badendpoint").Build()
 	assert.NoError(t, err)

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -809,6 +809,10 @@ func (client *GitLabClient) MergePullRequest(ctx context.Context, owner, repo st
 	return errGitLabMergePullRequestNotSupported
 }
 
+func (client *GitLabClient) CreatePullRequestDetailed(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) (CreatedPullRequestInfo, error) {
+	return CreatedPullRequestInfo{}, errGitlabCreatePullRequestDetailedNotSupported
+}
+
 func getProjectID(owner, project string) string {
 	return fmt.Sprintf("%s/%s", owner, project)
 }

--- a/vcsclient/gitlabcommon.go
+++ b/vcsclient/gitlabcommon.go
@@ -14,6 +14,7 @@ var errGitLabGetCollaboratorsNotSupported = errors.New("get collaborators is not
 var errGitLabGetRepoTeamsByPermissionsNotSupported = errors.New("get repository Teams By permissions is not supported on Gitlab")
 var errGitLabCreateOrUpdateEnvironmentNotSupported = errors.New("create or update environment is not supported on Gitlab")
 var errGitLabMergePullRequestNotSupported = errors.New("merging pull request is not supported on Gitlab")
+var errGitlabCreatePullRequestDetailedNotSupported = errors.New("creating pull request detailed is not supported on Gitlab")
 
 const (
 	// https://docs.gitlab.com/ee/api/merge_requests.html#create-mr

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -77,6 +77,14 @@ type CommitStatusInfo struct {
 	LastUpdatedAt time.Time
 }
 
+// PullRequestData contains the data returned from a pull request creation
+// number - The number of the pull request
+// URL - The URL of the pull request
+type CreatedPullRequestInfo struct {
+	Number int
+	URL    string
+}
+
 // VcsClient is a base class of all Vcs clients - GitHub, GitLab, Bitbucket server and cloud clients
 type VcsClient interface {
 	// TestConnection Returns nil if connection and authorization established successfully
@@ -344,6 +352,15 @@ type VcsClient interface {
 
 	// MergePullRequest merges a pull request into the target branch
 	MergePullRequest(ctx context.Context, owner, repo string, prNumber int, commitMessage string) error
+
+	// CreatePullRequestDetailed Creates a pull request between 2 different branches in the same repository
+	// owner        - User or organization
+	// repository   - VCS repository name
+	// sourceBranch - Source branch
+	// targetBranch - Target branch
+	// title        - Pull request title
+	// description  - Pull request description
+	CreatePullRequestDetailed(ctx context.Context, owner, repository, sourceBranch, targetBranch, title, description string) (CreatedPullRequestInfo, error)
 }
 
 // CommitInfo contains the details of a commit


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [X] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [X] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [X] I added the relevant documentation for the new feature.

---
Added the new function for the github app which requires the pr number and link to the pr