### PR TITLE
Add pull request status to Github GetPullRequestByID response

### DIFF
--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -477,6 +477,7 @@ func mapGitHubPullRequestToPullRequestInfo(ghPullRequest *github.PullRequest, wi
 			Repository: targetRepoName,
 			Owner:      targetRepoOwner,
 		},
+		Status: vcsutils.DefaultIfNotNil(ghPullRequest.State),
 	}, nil
 }
 

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -674,6 +674,7 @@ func TestGitHubClient_ListOpenPullRequests(t *testing.T) {
 		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: owner},
 		URL:    "https://github.com/octocat/Hello-World/pull/1347",
+		Status: "open",
 	}, result[0])
 
 	_, err = createBadGitHubClient(t).ListPullRequestComments(ctx, owner, repo1, 1)
@@ -692,6 +693,7 @@ func TestGitHubClient_ListOpenPullRequests(t *testing.T) {
 		Source: BranchInfo{Name: "new-topic", Repository: "Hello-World", Owner: owner},
 		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: owner},
 		URL:    "https://github.com/octocat/Hello-World/pull/1347",
+		Status: "open",
 	}, result[0])
 
 	_, err = createBadGitHubClient(t).ListPullRequestComments(ctx, owner, repo1, 1)
@@ -720,6 +722,7 @@ func TestGitHubClient_GetPullRequestByID(t *testing.T) {
 		Target: BranchInfo{Name: "master", Repository: "Hello-World", Owner: forkedOwner},
 		URL:    "https://github.com/octocat/Hello-World/pull/1347",
 		Author: "octocat",
+		Status: "open",
 	}, result)
 
 	// Bad Labels

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -409,6 +409,7 @@ type PullRequestInfo struct {
 	Author string
 	Source BranchInfo
 	Target BranchInfo
+	Status string
 }
 
 type PullRequestReviewDetails struct {


### PR DESCRIPTION
Add pull request status to Github GetPullRequestByID response:

- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature.

---
Add pull request status to Github `GetPullRequestByID` response 