### PR TITLE
 Adding escaping to the branch name string in the download URL

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strconv"
@@ -146,7 +147,7 @@ func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, rep
 		client.connectionDetails.BaseUrl,
 		client.vcsInfo.Project,
 		repository,
-		branch)
+		url.QueryEscape(branch))
 	client.logger.Debug("Download url:", downloadRepoUrl)
 	headers := map[string]string{
 		"Authorization":  client.connectionDetails.AuthorizationString,


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature.

---

This PR is aiming to fix the following issue: 
In Azure Devops, in case there is a branch name that includes special character (for example: étab), there is an error when trying to download the repository (in sendDownloadRepoRequest()): "<Branch: {branch_name} > could not be resolved"

The fix: adding escaping to the branch name string, so it can be safely placed in the download URL.