### PR TITLE
Fix dependency submission api convertor

### DIFF
--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1651,7 +1651,7 @@ func (client *GitHubClient) UploadSnapshotToDependencyGraph(ctx context.Context,
 		return fmt.Errorf("failed to upload snapshot to dependency graph: %w", err)
 	}
 
-	if ghResponse == nil || ghResponse.Response == nil || (ghResponse.Response.StatusCode != http.StatusCreated && ghResponse.Response.StatusCode != http.StatusOK) {
+	if ghResponse == nil || ghResponse.Response == nil || ghResponse.Response.StatusCode != http.StatusCreated {
 		return fmt.Errorf("dependency submission call finished with unexpected status code: %d", ghResponse.Response.StatusCode)
 	} else {
 		client.logger.Info(vcsutils.SuccessfulSnapshotUpload, ghResponse.StatusCode)

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1635,17 +1635,27 @@ func (client *GitHubClient) UploadSnapshotToDependencyGraph(ctx context.Context,
 	if snapshot == nil {
 		return fmt.Errorf("provided snapshot is nil")
 	}
+
 	ghSnapshot, err := convertToGitHubSnapshot(snapshot)
 	if err != nil {
 		return fmt.Errorf("failed to convert snapshot to GitHub format: %w", err)
 	}
 
-	_, ghResponse, err := client.ghClient.DependencyGraph.CreateSnapshot(ctx, owner, repo, ghSnapshot)
+	var ghResponse *github.Response
+	err = client.runWithRateLimitRetries(func() (*github.Response, error) {
+		_, ghResponse, err = client.ghClient.DependencyGraph.CreateSnapshot(ctx, owner, repo, ghSnapshot)
+		return ghResponse, err
+	})
+
 	if err != nil {
 		return fmt.Errorf("failed to upload snapshot to dependency graph: %w", err)
 	}
 
-	client.logger.Info(vcsutils.SuccessfulSnapshotUpload, ghResponse.StatusCode)
+	if ghResponse != nil && ghResponse.Response != nil && ghResponse.Response.StatusCode != http.StatusCreated {
+		return fmt.Errorf("dependency submission call finished with unexpected status code: %d", ghResponse.Response.StatusCode)
+	} else {
+		client.logger.Info(vcsutils.SuccessfulSnapshotUpload, ghResponse.StatusCode)
+	}
 	return nil
 }
 
@@ -1696,6 +1706,7 @@ func convertToGitHubSnapshot(snapshot *SbomSnapshot) (*github.DependencyGraphSna
 			ghDep := &github.DependencyGraphSnapshotResolvedDependency{
 				PackageURL:   &dep.PackageURL,
 				Dependencies: dep.Dependencies,
+				Relationship: &dep.Relationship,
 			}
 			ghManifest.Resolved[depName] = ghDep
 		}

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1651,7 +1651,7 @@ func (client *GitHubClient) UploadSnapshotToDependencyGraph(ctx context.Context,
 		return fmt.Errorf("failed to upload snapshot to dependency graph: %w", err)
 	}
 
-	if ghResponse != nil && ghResponse.Response != nil && ghResponse.Response.StatusCode != http.StatusCreated {
+	if ghResponse == nil || ghResponse.Response == nil || (ghResponse.Response.StatusCode != http.StatusCreated && ghResponse.Response.StatusCode != http.StatusOK) {
 		return fmt.Errorf("dependency submission call finished with unexpected status code: %d", ghResponse.Response.StatusCode)
 	} else {
 		client.logger.Info(vcsutils.SuccessfulSnapshotUpload, ghResponse.StatusCode)

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1653,9 +1653,9 @@ func (client *GitHubClient) UploadSnapshotToDependencyGraph(ctx context.Context,
 
 	if ghResponse == nil || ghResponse.Response == nil || ghResponse.Response.StatusCode != http.StatusCreated {
 		return fmt.Errorf("dependency submission call finished with unexpected status code: %d", ghResponse.Response.StatusCode)
-	} else {
-		client.logger.Info(vcsutils.SuccessfulSnapshotUpload, ghResponse.StatusCode)
 	}
+
+	client.logger.Info(vcsutils.SuccessfulSnapshotUpload, ghResponse.StatusCode)
 	return nil
 }
 

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1570,7 +1570,7 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 	}
 	resolvedPackages["@actions/http-client"] = &ResolvedDependency{
 		PackageURL:   "pkg:/npm/%40actions/http-client@1.0.1",
-		Relationship: "direct",
+		Relationship: "indirect",
 		Dependencies: []string{"tunnel"},
 	}
 	resolvedPackages["tunnel"] = &ResolvedDependency{

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1598,7 +1598,7 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 		Manifests: manifests,
 	}
 
-	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, nil, expectedURI, createGitHubHandler)
+	client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitHub, false, nil, expectedURI, http.StatusCreated, createGitHubHandler)
 	defer cleanUp()
 
 	err := client.UploadSnapshotToDependencyGraph(ctx, owner, repo1, &snapshot)


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [ ] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [ ] I added the relevant documentation for the new feature.

---
This PR adds the missed 'Relationship' field to the handler's convertor and improves current API implementation