### PR TITLE
improved `CreateBranch` and `CommitAndPushFiles` performance 

### DIFF
--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1069,9 +1069,9 @@ func (client *GitHubClient) CreateBranch(ctx context.Context, owner, repository,
 		return err
 	}
 
-	var sourceBranchRef *github.Branch
+	var sourceBranchRef *github.Reference
 	err = client.runWithRateLimitRetries(func() (*github.Response, error) {
-		sourceBranchRef, _, err = client.ghClient.Repositories.GetBranch(ctx, owner, repository, sourceBranch, 3)
+		sourceBranchRef, _, err = client.ghClient.Git.GetRef(ctx, owner, repository, "refs/heads/"+sourceBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -1081,7 +1081,14 @@ func (client *GitHubClient) CreateBranch(ctx context.Context, owner, repository,
 		return err
 	}
 
-	latestCommitSHA := sourceBranchRef.Commit.SHA
+	if sourceBranchRef == nil {
+		return fmt.Errorf("failed to get reference for source branch %s", sourceBranch)
+	}
+	if sourceBranchRef.Object == nil {
+		return fmt.Errorf("source branch %s reference object is nil", sourceBranch)
+	}
+
+	latestCommitSHA := sourceBranchRef.Object.SHA
 	ref := &github.Reference{
 		Ref:    github.String("refs/heads/" + newBranch),
 		Object: &github.GitObject{SHA: latestCommitSHA},
@@ -1280,6 +1287,54 @@ func (client *GitHubClient) CommitAndPushFiles(
 		return errors.New("no files provided to commit")
 	}
 
+	if len(files) == 1 {
+		client.logger.Debug("Using Contents API for single file commit")
+		return client.commitSingleFile(ctx, owner, repo, sourceBranch, files[0], commitMessage, authorName, authorEmail)
+	}
+
+	client.logger.Debug("Using Git API for", len(files), " file commit")
+	return client.commitMultipleFiles(ctx, owner, repo, sourceBranch, files, commitMessage, authorName, authorEmail)
+}
+
+func (client *GitHubClient) commitSingleFile(
+	ctx context.Context,
+	owner, repo, branch string,
+	file FileToCommit,
+	commitMessage, authorName, authorEmail string,
+) error {
+	encodedContent := base64Utils.StdEncoding.EncodeToString([]byte(file.Content))
+
+	fileOptions := &github.RepositoryContentFileOptions{
+		Message: &commitMessage,
+		Content: []byte(encodedContent),
+		Branch:  &branch,
+		Author: &github.CommitAuthor{
+			Name:  &authorName,
+			Email: &authorEmail,
+		},
+		Committer: &github.CommitAuthor{
+			Name:  &authorName,
+			Email: &authorEmail,
+		},
+	}
+
+	err := client.runWithRateLimitRetries(func() (*github.Response, error) {
+		_, ghResponse, err := client.ghClient.Repositories.CreateFile(ctx, owner, repo, file.Path, fileOptions)
+		return ghResponse, err
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to commit single file %s: %w", file.Path, err)
+	}
+	return nil
+}
+
+func (client *GitHubClient) commitMultipleFiles(
+	ctx context.Context,
+	owner, repo, sourceBranch string,
+	files []FileToCommit,
+	commitMessage, authorName, authorEmail string,
+) error {
 	ref, _, err := client.ghClient.Git.GetRef(ctx, owner, repo, "refs/heads/"+sourceBranch)
 	if err != nil {
 		return fmt.Errorf("failed to get branch ref: %w", err)
@@ -1290,23 +1345,9 @@ func (client *GitHubClient) CommitAndPushFiles(
 		return fmt.Errorf("failed to get parent commit: %w", err)
 	}
 
-	var treeEntries []*github.TreeEntry
-	for _, file := range files {
-		blob, _, err := client.ghClient.Git.CreateBlob(ctx, owner, repo, &github.Blob{
-			Content:  github.String(file.Content),
-			Encoding: github.String("utf-8"),
-		})
-		if err != nil {
-			return fmt.Errorf("failed to create blob for %s: %w", file.Path, err)
-		}
-
-		// Add each file to the treeEntries
-		treeEntries = append(treeEntries, &github.TreeEntry{
-			Path: github.String(file.Path),
-			Mode: github.String(regularFileCode),
-			Type: github.String("blob"),
-			SHA:  blob.SHA,
-		})
+	treeEntries, err := client.createBlobsInParallel(ctx, owner, repo, files)
+	if err != nil {
+		return err
 	}
 
 	tree, _, err := client.ghClient.Git.CreateTree(ctx, owner, repo, *parentCommit.Tree.SHA, treeEntries)
@@ -1336,6 +1377,56 @@ func (client *GitHubClient) CommitAndPushFiles(
 		return fmt.Errorf("failed to update branch ref: %w", err)
 	}
 	return nil
+}
+
+func (client *GitHubClient) createBlobsInParallel(ctx context.Context, owner, repo string, files []FileToCommit) ([]*github.TreeEntry, error) {
+	type blobResult struct {
+		file  FileToCommit
+		blob  *github.Blob
+		err   error
+		index int
+	}
+
+	blobChan := make(chan blobResult, len(files))
+
+	for i, file := range files {
+		go func(idx int, f FileToCommit) {
+			err := client.runWithRateLimitRetries(func() (*github.Response, error) {
+				blob, ghResponse, err := client.ghClient.Git.CreateBlob(ctx, owner, repo, &github.Blob{
+					Content:  github.String(f.Content),
+					Encoding: github.String("utf-8"),
+				})
+				if err != nil {
+					blobChan <- blobResult{file: f, err: err, index: idx}
+				} else {
+					blobChan <- blobResult{file: f, blob: blob, index: idx}
+				}
+				return ghResponse, err
+			})
+			if err != nil && blobChan != nil {
+				blobChan <- blobResult{file: f, err: err, index: idx}
+			}
+		}(i, file)
+	}
+
+	treeEntries := make([]*github.TreeEntry, len(files))
+	for i := 0; i < len(files); i++ {
+		result := <-blobChan
+		if result.err != nil {
+			close(blobChan)
+			return nil, fmt.Errorf("failed to create blob for %s: %w", result.file.Path, result.err)
+		}
+
+		treeEntries[result.index] = &github.TreeEntry{
+			Path: github.String(result.file.Path),
+			Mode: github.String(regularFileCode),
+			Type: github.String("blob"),
+			SHA:  result.blob.SHA,
+		}
+	}
+	close(blobChan)
+
+	return treeEntries, nil
 }
 
 func (client *GitHubClient) MergePullRequest(ctx context.Context, owner, repo string, prNumber int, commitMessage string) error {

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1033,12 +1033,13 @@ func TestGitHubClient_DeletePullRequestComment(t *testing.T) {
 
 func TestGitHubClient_CreateBranch(t *testing.T) {
 	ctx := context.Background()
-	branchResponse := github.Branch{
-		Name:      github.String("master"),
-		Commit:    &github.RepositoryCommit{},
-		Protected: nil,
+	refResponse := github.Reference{
+		Ref: github.String("refs/heads/master"),
+		Object: &github.GitObject{
+			SHA: github.String("abc123abc123abc123abc123abc123abc123abcd"),
+		},
 	}
-	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, branchResponse, "", createGitHubHandlerWithoutExpectedURI)
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, refResponse, "", createGitHubHandlerWithoutExpectedURI)
 	defer cleanUp()
 	err := client.CreateBranch(ctx, owner, repo1, "master", "BranchForTest")
 	assert.NoError(t, err)
@@ -1093,6 +1094,7 @@ func TestGitHubClient_CommitAndPushFiles(t *testing.T) {
 	sourceBranch := "feature-branch"
 	filesToCommit := []FileToCommit{
 		{Path: "example.txt", Content: "example content"},
+		{Path: "example2.txt", Content: "example content 2"},
 	}
 	expectedResponses := map[string]mockGitHubResponse{
 		"/repos/jfrog/repo-1/git/ref/heads/feature-branch": {


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [X] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [X] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [X] I added the relevant documentation for the new feature.

---
Optimized file commits: Single files use Contents API, multiple files use Git API with parallel blob creation
Added concurrent processing for multi-file operations by using `createBlobsInParallel()`
Fixed nil pointer crash in `CreateBranch` method by switching from `GetBranch()` to `GetRef()` API and adding null checks