### PR TITLE
Add code scanning is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Currently supported providers are: [GitHub](#github), [Bitbucket Server](#bitbuc
       - [List Pull Request Labels](#list-pull-request-labels)
       - [Unlabel Pull Request](#unlabel-pull-request)
       - [Upload Code Scanning](#upload-code-scanning)
+      - [Check If Code Scanning Is Enabled](#check-if-code-scanning-is-enabled)
       - [Download a File From a Repository](#download-a-file-from-a-repository)
       - [Create a branch](#create-branch)
       - [Allow workflows on organization](#allow-workflows)
@@ -834,6 +835,22 @@ scanResults := "results"
 
 // Uploads the scanning analysis file to the relevant git provider
 sarifID, err := client.UploadCodeScanning(ctx, owner, repo, branch, scanResults)
+```
+
+#### Check If Code Scanning Is Enabled
+
+Notice - Code Scanning availability check is currently supported on GitHub only.
+
+```go
+// Go context
+ctx := context.Background()
+// The account owner of the git repository
+owner := "user"
+// The name of the repository
+repo := "my_repo"
+
+// Checks if code scanning is enabled for the repository
+enabled, err := client.IsCodeScanningEnabled(ctx, owner, repo)
 ```
 
 #### Download a File From a Repository

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
+	github.com/google/go-github/v53 v53.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
+github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
 github.com/google/go-github/v62 v62.0.0 h1:/6mGCaRywZz9MuHyw9gD1CwsbmBX8GWsbFkwMmHdhl4=
 github.com/google/go-github/v62 v62.0.0/go.mod h1:EMxeUqGJq2xRu9DYBMwel/mr7kZrzUOfQmmpYrZn2a4=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -789,6 +789,10 @@ func (client *AzureReposClient) UploadSnapshotToDependencyGraph(ctx context.Cont
 	return getUnsupportedInAzureError("uploading snapshot to dependency graph UI")
 }
 
+func (client *AzureReposClient) IsCodeScanningEnabled(ctx context.Context, owner, repository string) (bool, error) {
+	return false, getUnsupportedInAzureError("code scanning")
+}
+
 func parsePullRequestDetails(client *AzureReposClient, pullRequest git.GitPullRequest, owner, repository string, withBody bool) PullRequestInfo {
 	// Trim the branches prefix and get the actual branches name
 	shortSourceName := plumbing.ReferenceName(*pullRequest.SourceRefName).Short()

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -747,6 +747,10 @@ func (client *BitbucketCloudClient) UploadSnapshotToDependencyGraph(ctx context.
 	return errBitbucketUploadSnapshotToDependencyGraphNotSupported
 }
 
+func (client *BitbucketCloudClient) IsCodeScanningEnabled(ctx context.Context, owner, repository string) (bool, error) {
+	return false, errBitbucketCodeScanningNotSupported
+}
+
 type pullRequestsResponse struct {
 	Values []pullRequestsDetails `json:"values"`
 }

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -2,9 +2,10 @@ package vcsclient
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/mitchellh/mapstructure"
-	"time"
 )
 
 const (

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -939,6 +939,10 @@ func (client *BitbucketServerClient) UploadSnapshotToDependencyGraph(ctx context
 	return errBitbucketUploadSnapshotToDependencyGraphNotSupported
 }
 
+func (client *BitbucketServerClient) IsCodeScanningEnabled(ctx context.Context, owner, repository string) (bool, error) {
+	return false, errBitbucketCodeScanningNotSupported
+}
+
 func getBitbucketServerRepositoryVisibility(public bool) RepositoryVisibility {
 	if public {
 		return Public

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1608,3 +1608,97 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 	err = createBadGitHubClient(t).UploadSnapshotToDependencyGraph(ctx, owner, repo1, &snapshot)
 	assert.Error(t, err)
 }
+
+func TestGitHubClient_IsCodeScanningEnabled(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("code scanning enabled - 422 response", func(t *testing.T) {
+		unprocessableResponse := []byte(`{
+			"message": "Invalid request",
+			"errors": [
+				{
+					"code": "invalid",
+					"field": "sarif"
+				}
+			]
+		}`)
+
+		client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitHub, false, unprocessableResponse,
+			fmt.Sprintf("/repos/%s/%s/code-scanning/sarifs", owner, repo1), http.StatusUnprocessableEntity,
+			createGitHubHandler)
+		defer cleanUp()
+
+		enabled, err := client.IsCodeScanningEnabled(ctx, owner, repo1)
+		assert.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("code scanning disabled - 403 with code scanning message", func(t *testing.T) {
+		forbiddenResponse := []byte(`{
+			"message": "Advanced Security must be enabled for this repository to use code scanning.",
+			"documentation_url": "https://docs.github.com/rest/reference/code-scanning"
+		}`)
+
+		client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitHub, false, forbiddenResponse,
+			fmt.Sprintf("/repos/%s/%s/code-scanning/sarifs", owner, repo1), http.StatusForbidden,
+			createGitHubHandler)
+		defer cleanUp()
+
+		enabled, err := client.IsCodeScanningEnabled(ctx, owner, repo1)
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("generic forbidden - 403 without code scanning message", func(t *testing.T) {
+		genericForbiddenResponse := []byte(`{
+			"message": "Forbidden"
+		}`)
+
+		client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitHub, false, genericForbiddenResponse,
+			fmt.Sprintf("/repos/%s/%s/code-scanning/sarifs", owner, repo1), http.StatusForbidden,
+			createGitHubHandler)
+		defer cleanUp()
+
+		enabled, err := client.IsCodeScanningEnabled(ctx, owner, repo1)
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("unexpected success - 200 response", func(t *testing.T) {
+		successResponse := []byte(`{"message": "Success"}`)
+
+		client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitHub, false, successResponse,
+			fmt.Sprintf("/repos/%s/%s/code-scanning/sarifs", owner, repo1), http.StatusOK,
+			createGitHubHandler)
+		defer cleanUp()
+
+		enabled, err := client.IsCodeScanningEnabled(ctx, owner, repo1)
+		assert.NoError(t, err)
+		assert.True(t, enabled) // Should return true but log a warning
+	})
+
+	t.Run("network error", func(t *testing.T) {
+		enabled, err := createBadGitHubClient(t).IsCodeScanningEnabled(ctx, owner, repo1)
+		assert.Error(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("invalid parameters", func(t *testing.T) {
+		client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitHub, false, nil,
+			fmt.Sprintf("/repos/%s/%s/code-scanning/sarifs", owner, repo1), http.StatusUnprocessableEntity,
+			createGitHubHandler)
+		defer cleanUp()
+
+		// Test empty owner
+		enabled, err := client.IsCodeScanningEnabled(ctx, "", repo1)
+		assert.Error(t, err)
+		assert.False(t, enabled)
+		assert.Contains(t, err.Error(), "owner")
+
+		// Test empty repository
+		enabled, err = client.IsCodeScanningEnabled(ctx, owner, "")
+		assert.Error(t, err)
+		assert.False(t, enabled)
+		assert.Contains(t, err.Error(), "repository")
+	})
+}

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -827,6 +827,10 @@ func (client *GitLabClient) UploadSnapshotToDependencyGraph(ctx context.Context,
 	return errGitLabUploadSnapshotToDependencyGraphNotSupported
 }
 
+func (client *GitLabClient) IsCodeScanningEnabled(ctx context.Context, owner, repository string) (bool, error) {
+	return false, errGitLabCodeScanningNotSupported
+}
+
 func getProjectID(owner, project string) string {
 	return fmt.Sprintf("%s/%s", owner, project)
 }

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -396,6 +396,12 @@ type VcsClient interface {
 
 	// UploadSnapshotToDependencyGraph uploads a snapshot to the GitHub dependency graph tab
 	UploadSnapshotToDependencyGraph(ctx context.Context, owner, repo string, snapshot *SbomSnapshot) error
+
+	// IsCodeScanningEnabled checks if code scanning is enabled by making a direct HTTP request
+	// to the code scanning route with an empty body and interpreting the response status codes
+	// owner      - User or organization
+	// repository - VCS repository name
+	IsCodeScanningEnabled(ctx context.Context, owner, repository string) (bool, error)
 }
 
 // SbomSnapshot represents a snapshot for GitHub dependency submission API


### PR DESCRIPTION
- [X] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [X] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [ ] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [X] I added the relevant documentation for the new feature.

---
Checks if code scanning is available in GitHub by trying to make the upload request with an empty body and mapping the response to `true` or `false`