### PR TITLE
Fix Azure repos `GetRepositoryInfo` to handle missing clone info

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -533,8 +533,22 @@ func (client *AzureReposClient) GetRepositoryInfo(ctx context.Context, owner, re
 	if visibilityFromResponse == core.ProjectVisibilityValues.Public {
 		visibility = Public
 	}
+
+	cloneInfo := CloneInfo{}
+	if response.RemoteUrl != nil {
+		cloneInfo.HTTP = *response.RemoteUrl
+	} else {
+		client.logger.Info(fmt.Sprintf("HTTPS clone URL not available for repository %s/%s/%s (may be disabled or not configured)", owner, client.vcsInfo.Project, repository))
+	}
+
+	if response.SshUrl != nil {
+		cloneInfo.SSH = *response.SshUrl
+	} else {
+		client.logger.Info(fmt.Sprintf("SSH clone URL not available for repository %s/%s/%s (may be disabled or not configured)", owner, client.vcsInfo.Project, repository))
+	}
+
 	return RepositoryInfo{
-		CloneInfo:            CloneInfo{HTTP: *response.RemoteUrl, SSH: *response.SshUrl},
+		CloneInfo:            cloneInfo,
 		RepositoryVisibility: visibility,
 	}, nil
 }


### PR DESCRIPTION
- Add nil checks for response.RemoteUrl and response.SshUrl
- Log informative messages when URLs are missing instead of panicking
- Return empty strings for missing URLs to maintain compatibility
- Prevents runtime panics when SSH/HTTPS is disabled in Azure DevOps

- [x] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [x] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [x] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [x] I added the relevant documentation for the new feature.

---


Added more informative logs about missing data for azure clone info

some of the fields may be empty per configurations of an org in a self hosted env