### PR TITLE
Trigger Workflow Support For Github

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -791,6 +791,10 @@ func (client *AzureReposClient) AllowWorkflows(ctx context.Context, owner string
 	return getUnsupportedInAzureError("allow workflows")
 }
 
+func (client *AzureReposClient) TriggerWorkflow(_ context.Context, _, _, _ string, _ map[string]interface{}) error {
+	return getUnsupportedInAzureError("trigger workflow")
+}
+
 func (client *AzureReposClient) AddOrganizationSecret(ctx context.Context, owner, secretName, secretValue string) error {
 	return getUnsupportedInAzureError("add organization secret")
 }

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -945,6 +945,10 @@ func (client *BitbucketCloudClient) AllowWorkflows(ctx context.Context, owner st
 	return errBitbucketAllowWorkflowsNotSupported
 }
 
+func (client *BitbucketCloudClient) TriggerWorkflow(_ context.Context, _, _, _ string, _ map[string]interface{}) error {
+	return errBitbucketTriggerWorkflowNotSupported
+}
+
 func (client *BitbucketCloudClient) AddOrganizationSecret(ctx context.Context, owner, secretName, secretValue string) error {
 	return errBitbucketAddOrganizationSecretNotSupported
 }

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -23,6 +23,7 @@ var (
 	errBitbucketListListPullRequestReviewsNotSupported       = fmt.Errorf("list pull request reviews is %s", notSupportedOnBitbucket)
 	errBitbucketCreateBranchNotSupported                     = fmt.Errorf("creating a branch is %s", notSupportedOnBitbucket)
 	errBitbucketAllowWorkflowsNotSupported                   = fmt.Errorf("allow workflows is %s", notSupportedOnBitbucket)
+	errBitbucketTriggerWorkflowNotSupported                  = fmt.Errorf("trigger workflow is %s", notSupportedOnBitbucket)
 	errBitbucketAddOrganizationSecretNotSupported            = fmt.Errorf("adding organization secret is %s", notSupportedOnBitbucket)
 	errBitbucketCreateOrgVariableNotSupported                = fmt.Errorf("creating organization variable is %s", notSupportedOnBitbucket)
 	errBitbucketCommitAndPushFilesNotSupported               = fmt.Errorf("commit and push files is %s", notSupportedOnBitbucket)

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -932,6 +932,10 @@ func (client *BitbucketServerClient) AllowWorkflows(ctx context.Context, owner s
 	return errBitbucketAllowWorkflowsNotSupported
 }
 
+func (client *BitbucketServerClient) TriggerWorkflow(_ context.Context, _, _, _ string, _ map[string]interface{}) error {
+	return errBitbucketTriggerWorkflowNotSupported
+}
+
 func (client *BitbucketServerClient) AddOrganizationSecret(ctx context.Context, owner, secretName, secretValue string) error {
 	return errBitbucketAddOrganizationSecretNotSupported
 }

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	base64Utils "encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -1234,6 +1235,27 @@ func (client *GitHubClient) AllowWorkflows(ctx context.Context, owner string) er
 		return nil, err
 	})
 	return err
+}
+
+func (client *GitHubClient) TriggerWorkflow(ctx context.Context, owner, repo, eventType string, payload map[string]interface{}) error {
+	err := validateParametersNotBlank(map[string]string{"owner": owner, "repo": repo, "eventType": eventType})
+	if err != nil {
+		return err
+	}
+
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal workflow payload: %w", err)
+	}
+	raw := json.RawMessage(rawPayload)
+
+	return client.runWithRateLimitRetries(func() (*github.Response, error) {
+		_, resp, err := client.ghClient.Repositories.Dispatch(ctx, owner, repo, github.DispatchRequestOptions{
+			EventType:     eventType,
+			ClientPayload: &raw,
+		})
+		return resp, err
+	})
 }
 
 func (client *GitHubClient) GetRepoCollaborators(ctx context.Context, owner, repo, affiliation, permission string) ([]string, error) {

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1118,6 +1118,23 @@ func TestGitHubClient_AllowWorkflows(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestGitHubClient_TriggerWorkflow(t *testing.T) {
+	ctx := context.Background()
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, nil,
+		fmt.Sprintf("/repos/%s/%s/dispatches", owner, repo1), createGitHubHandler)
+	defer cleanUp()
+	err := client.TriggerWorkflow(ctx, owner, repo1, "jfrog-auto-fix", map[string]interface{}{
+		"component_name":   "org.apache.commons:commons-lang3",
+		"affected_version": "3.12.0",
+		"fix_version":      "3.14.0",
+	})
+	assert.NoError(t, err)
+
+	// Bad client should return an error
+	err = createBadGitHubClient(t).TriggerWorkflow(ctx, owner, repo1, "jfrog-auto-fix", nil)
+	assert.Error(t, err)
+}
+
 func TestGitHubClient_AddOrganizationSecret(t *testing.T) {
 	ctx := context.Background()
 	publicKeyResponse := github.PublicKey{

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -841,6 +841,10 @@ func (client *GitLabClient) AllowWorkflows(ctx context.Context, owner string) er
 	return errGitLabAllowWorkflowsNotSupported
 }
 
+func (client *GitLabClient) TriggerWorkflow(_ context.Context, _, _, _ string, _ map[string]interface{}) error {
+	return errGitLabTriggerWorkflowNotSupported
+}
+
 func (client *GitLabClient) AddOrganizationSecret(ctx context.Context, owner, secretName, secretValue string) error {
 	return errGitLLabAddOrganizationSecretNotSupported
 }

--- a/vcsclient/gitlabcommon.go
+++ b/vcsclient/gitlabcommon.go
@@ -8,6 +8,7 @@ var errGitLabCodeScanningNotSupported = errors.New("code scanning is not support
 var errGitLabGetRepoEnvironmentInfoNotSupported = errors.New("get repository environment info is currently not supported on Gitlab")
 var errGitLabCreateBranchNotSupported = errors.New("creating a branch is not supported on Gitlab")
 var errGitLabAllowWorkflowsNotSupported = errors.New("allow workflows is not supported on Gitlab")
+var errGitLabTriggerWorkflowNotSupported = errors.New("trigger workflow is not supported on Gitlab")
 var errGitLLabAddOrganizationSecretNotSupported = errors.New("adding organization secret is not supported on Gitlab")
 var errGitLabCreateOrgVariableNotSupported = errors.New("creating organization variable is not supported on Gitlab")
 var errGitLabCommitAndPushFilesNotSupported = errors.New("commit and push files is not supported on Gitlab")

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -387,7 +387,7 @@ type VcsClient interface {
 
 	// TriggerWorkflow sends a repository_dispatch event to trigger a workflow in the given repository.
 	// eventType is the custom event type string that the workflow listens on.
-	// payload is an arbitrary key-value map that will be available as github.event.client_payload in the workflow.
+	// payload is an arbitrary key-value map that will be available as extra information about the webhook
 	TriggerWorkflow(ctx context.Context, owner, repo, eventType string, payload map[string]interface{}) error
 
 	// AddOrganizationSecret adds a secret to the organization

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -386,7 +386,7 @@ type VcsClient interface {
 	AllowWorkflows(ctx context.Context, owner string) error
 
 	// TriggerWorkflow sends a repository_dispatch event to trigger a workflow in the given repository.
-	// eventType is the custom event type string that the workflow listens on.
+	// eventType is a custom webhook event name. (Required), Workflows can listen to this event type
 	// payload is an arbitrary key-value map that will be available as extra information about the webhook
 	TriggerWorkflow(ctx context.Context, owner, repo, eventType string, payload map[string]interface{}) error
 

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -385,6 +385,11 @@ type VcsClient interface {
 	// AllowWorkflows allows the user to enable or disable workflows for an organization
 	AllowWorkflows(ctx context.Context, owner string) error
 
+	// TriggerWorkflow sends a repository_dispatch event to trigger a workflow in the given repository.
+	// eventType is the custom event type string that the workflow listens on.
+	// payload is an arbitrary key-value map that will be available as github.event.client_payload in the workflow.
+	TriggerWorkflow(ctx context.Context, owner, repo, eventType string, payload map[string]interface{}) error
+
 	// AddOrganizationSecret adds a secret to the organization
 	AddOrganizationSecret(ctx context.Context, owner, secretName, secretValue string) error
 


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [ ] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [ ] I added the relevant documentation for the new feature.

---
