### PR TITLE
Add GetMergeBase to VcsClient (all five providers)

### DIFF
--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -943,16 +943,13 @@ func (client *AzureReposClient) GetMergeBase(ctx context.Context, _, repository,
 	}
 
 	// Azure rejects anything that is not a 40 character object id, on both sides of the comparison.
-	baseCommit, err := client.GetLatestCommit(ctx, "", repository, refBefore)
+	baseSha, err := client.resolveToCommitSha(ctx, repository, refBefore)
 	if err != nil {
 		return CommitInfo{}, err
 	}
-	otherCommit, err := client.GetLatestCommit(ctx, "", repository, refAfter)
+	otherSha, err := client.resolveToCommitSha(ctx, repository, refAfter)
 	if err != nil {
 		return CommitInfo{}, err
-	}
-	if baseCommit.Hash == "" || otherCommit.Hash == "" {
-		return CommitInfo{}, fmt.Errorf("could not resolve '%s' and '%s' to commits in <%s>", refBefore, refAfter, repository)
 	}
 
 	azureReposGitClient, err := client.buildAzureReposClient(ctx)
@@ -962,8 +959,8 @@ func (client *AzureReposClient) GetMergeBase(ctx context.Context, _, repository,
 	mergeBases, err := azureReposGitClient.GetMergeBases(ctx, git.GetMergeBasesArgs{
 		RepositoryNameOrId: &repository,
 		Project:            &client.vcsInfo.Project,
-		CommitId:           &baseCommit.Hash,
-		OtherCommitId:      &otherCommit.Hash,
+		CommitId:           &baseSha,
+		OtherCommitId:      &otherSha,
 	})
 	if err != nil {
 		return CommitInfo{}, err
@@ -972,4 +969,18 @@ func (client *AzureReposClient) GetMergeBase(ctx context.Context, _, repository,
 		return CommitInfo{}, fmt.Errorf("no merge base found for <%s> between %s and %s", repository, refBefore, refAfter)
 	}
 	return mapAzureReposCommitsToCommitInfo((*mergeBases)[0]), nil
+}
+
+func (client *AzureReposClient) resolveToCommitSha(ctx context.Context, repository, ref string) (string, error) {
+	if commitShaRegex.MatchString(ref) {
+		return ref, nil
+	}
+	commit, err := client.GetLatestCommit(ctx, "", repository, ref)
+	if err != nil {
+		return "", err
+	}
+	if commit.Hash == "" {
+		return "", fmt.Errorf("could not resolve '%s' to a commit in <%s>", ref, repository)
+	}
+	return commit.Hash, nil
 }

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -924,3 +924,8 @@ func mapVoteToState(vote int) string {
 		return "UNKNOWN"
 	}
 }
+
+// GetMergeBase on Azure Repos
+func (client *AzureReposClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
+	return CommitInfo{}, ErrMergeBaseUnsupported
+}

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -46,8 +45,6 @@ func NewAzureReposClient(vcsInfo VcsInfo, logger vcsutils.Log) (*AzureReposClien
 	client.connectionDetails = azuredevops.NewPatConnection(baseUrl, client.vcsInfo.Token)
 	return client, nil
 }
-
-var commitShaRegex = regexp.MustCompile("^[0-9a-fA-F]{40}$")
 
 func (client *AzureReposClient) buildAzureReposClient(ctx context.Context) (git.Client, error) {
 	if client.connectionDetails == nil {
@@ -948,7 +945,6 @@ func (client *AzureReposClient) GetMergeBase(ctx context.Context, _, repository,
 		return CommitInfo{}, err
 	}
 
-	// Azure rejects anything that is not a 40 character object id, on both sides of the comparison.
 	baseSha, err := client.resolveToCommitSha(ctx, repository, refBefore)
 	if err != nil {
 		return CommitInfo{}, err
@@ -977,10 +973,8 @@ func (client *AzureReposClient) GetMergeBase(ctx context.Context, _, repository,
 	return mapAzureReposCommitsToCommitInfo((*mergeBases)[0]), nil
 }
 
+// Azure resolves merge bases only by object id, so a branch name has to be turned into one first.
 func (client *AzureReposClient) resolveToCommitSha(ctx context.Context, repository, ref string) (string, error) {
-	if commitShaRegex.MatchString(ref) {
-		return ref, nil
-	}
 	commit, err := client.GetLatestCommit(ctx, "", repository, ref)
 	if err != nil {
 		return "", err

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -937,11 +937,11 @@ func mapVoteToState(vote int) string {
 
 // GetMergeBase on Azure Repos
 func (client *AzureReposClient) GetMergeBase(ctx context.Context, _, repository, refBefore, refAfter string) (CommitInfo, error) {
-	if err := validateParametersNotBlank(map[string]string{
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err := errors.Join(
+		validateNotBlank("repository", repository),
+		validateNotBlank("refBefore", refBefore),
+		validateNotBlank("refAfter", refAfter),
+	); err != nil {
 		return CommitInfo{}, err
 	}
 

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -45,6 +46,8 @@ func NewAzureReposClient(vcsInfo VcsInfo, logger vcsutils.Log) (*AzureReposClien
 	client.connectionDetails = azuredevops.NewPatConnection(baseUrl, client.vcsInfo.Token)
 	return client, nil
 }
+
+var commitShaRegex = regexp.MustCompile("^[0-9a-fA-F]{40}$")
 
 func (client *AzureReposClient) buildAzureReposClient(ctx context.Context) (git.Client, error) {
 	if client.connectionDetails == nil {
@@ -165,6 +168,10 @@ func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, rep
 		client.vcsInfo.Project,
 		repository,
 		url.QueryEscape(branch))
+	// Azure defaults the version type to a branch name, and answers 404 for a commit id unless told otherwise.
+	if commitShaRegex.MatchString(branch) {
+		downloadRepoUrl += "&versionDescriptor[versionType]=commit"
+	}
 	client.logger.Debug("Download url:", downloadRepoUrl)
 	headers := map[string]string{
 		"Authorization":  client.connectionDetails.AuthorizationString,

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -120,7 +120,16 @@ func (client *AzureReposClient) ListBranches(ctx context.Context, _, repository 
 }
 
 // DownloadRepository on Azure Repos
-func (client *AzureReposClient) DownloadRepository(ctx context.Context, owner, repository, branch, localPath string) (err error) {
+func (client *AzureReposClient) DownloadRepository(ctx context.Context, owner, repository, branch, localPath string) error {
+	return client.downloadRepositoryAtVersion(ctx, owner, repository, branch, string(git.GitVersionTypeValues.Branch), localPath)
+}
+
+// DownloadRepositoryByCommit on Azure Repos
+func (client *AzureReposClient) DownloadRepositoryByCommit(ctx context.Context, owner, repository, commitSha, localPath string) error {
+	return client.downloadRepositoryAtVersion(ctx, owner, repository, commitSha, string(git.GitVersionTypeValues.Commit), localPath)
+}
+
+func (client *AzureReposClient) downloadRepositoryAtVersion(ctx context.Context, owner, repository, version, versionType, localPath string) (err error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return
@@ -132,7 +141,7 @@ func (client *AzureReposClient) DownloadRepository(ctx context.Context, owner, r
 	defer func() {
 		err = errors.Join(err, os.Chdir(wd))
 	}()
-	res, err := client.sendDownloadRepoRequest(ctx, repository, branch)
+	res, err := client.sendDownloadRepoRequest(ctx, repository, version, versionType)
 	defer func() {
 		if res.Body != nil {
 			err = errors.Join(err, res.Body.Close())
@@ -162,16 +171,13 @@ func (client *AzureReposClient) DownloadRepository(ctx context.Context, owner, r
 		httpsCloneUrl)
 }
 
-func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, repository string, branch string) (res *http.Response, err error) {
-	downloadRepoUrl := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/items/items?path=/&versionDescriptor[version]=%s&$format=zip",
+func (client *AzureReposClient) sendDownloadRepoRequest(ctx context.Context, repository, version, versionType string) (res *http.Response, err error) {
+	downloadRepoUrl := fmt.Sprintf("%s/%s/_apis/git/repositories/%s/items/items?path=/&versionDescriptor[version]=%s&versionDescriptor[versionType]=%s&$format=zip",
 		client.connectionDetails.BaseUrl,
 		client.vcsInfo.Project,
 		repository,
-		url.QueryEscape(branch))
-	// Azure defaults the version type to a branch name, and answers 404 for a commit id unless told otherwise.
-	if commitShaRegex.MatchString(branch) {
-		downloadRepoUrl += "&versionDescriptor[versionType]=commit"
-	}
+		url.QueryEscape(version),
+		versionType)
 	client.logger.Debug("Download url:", downloadRepoUrl)
 	headers := map[string]string{
 		"Authorization":  client.connectionDetails.AuthorizationString,

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -140,7 +140,7 @@ func (client *AzureReposClient) downloadRepositoryAtVersion(ctx context.Context,
 	}()
 	res, err := client.sendDownloadRepoRequest(ctx, repository, version, versionType)
 	defer func() {
-		if res.Body != nil {
+		if res != nil && res.Body != nil {
 			err = errors.Join(err, res.Body.Close())
 		}
 	}()

--- a/vcsclient/azurerepos.go
+++ b/vcsclient/azurerepos.go
@@ -926,6 +926,43 @@ func mapVoteToState(vote int) string {
 }
 
 // GetMergeBase on Azure Repos
-func (client *AzureReposClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	return CommitInfo{}, ErrMergeBaseUnsupported
+func (client *AzureReposClient) GetMergeBase(ctx context.Context, _, repository, refBefore, refAfter string) (CommitInfo, error) {
+	if err := validateParametersNotBlank(map[string]string{
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
+		return CommitInfo{}, err
+	}
+
+	// Azure rejects anything that is not a 40 character object id, on both sides of the comparison.
+	baseCommit, err := client.GetLatestCommit(ctx, "", repository, refBefore)
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	otherCommit, err := client.GetLatestCommit(ctx, "", repository, refAfter)
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	if baseCommit.Hash == "" || otherCommit.Hash == "" {
+		return CommitInfo{}, fmt.Errorf("could not resolve '%s' and '%s' to commits in <%s>", refBefore, refAfter, repository)
+	}
+
+	azureReposGitClient, err := client.buildAzureReposClient(ctx)
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	mergeBases, err := azureReposGitClient.GetMergeBases(ctx, git.GetMergeBasesArgs{
+		RepositoryNameOrId: &repository,
+		Project:            &client.vcsInfo.Project,
+		CommitId:           &baseCommit.Hash,
+		OtherCommitId:      &otherCommit.Hash,
+	})
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	if mergeBases == nil || len(*mergeBases) == 0 {
+		return CommitInfo{}, fmt.Errorf("no merge base found for <%s> between %s and %s", repository, refBefore, refAfter)
+	}
+	return mapAzureReposCommitsToCommitInfo((*mergeBases)[0]), nil
 }

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -5,11 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/jfrog/froggit-go/vcsutils"
-	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
-	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
-	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/webapi"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +12,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jfrog/froggit-go/vcsutils"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/webapi"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAzureRepos_Connection(t *testing.T) {

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -114,7 +114,7 @@ func TestAzureRepos_TestDownloadRepository(t *testing.T) {
 	repoFile, err := os.ReadFile(filepath.Join("testdata", "azurerepos", "hello_world.zip"))
 	assert.NoError(t, err)
 
-	downloadURL := fmt.Sprintf("/%s/_apis/git/repositories/%s/items/items?path=/&versionDescriptor[version]=%s&$format=zip",
+	downloadURL := fmt.Sprintf("/%s/_apis/git/repositories/%s/items/items?path=/&versionDescriptor[version]=%s&versionDescriptor[versionType]=branch&$format=zip",
 		"",
 		repo1,
 		branch1)
@@ -947,7 +947,7 @@ func createBadAzureReposClient(t *testing.T, response []byte) (VcsClient, func()
 		vcsutils.AzureRepos,
 		true,
 		response,
-		fmt.Sprintf("bad^endpoint/%s/_apis/git/repositories/%s/items/items?path=/&versionDescriptor[version]=%s&$format=zip",
+		fmt.Sprintf("bad^endpoint/%s/_apis/git/repositories/%s/items/items?path=/&versionDescriptor[version]=%s&versionDescriptor[versionType]=branch&$format=zip",
 			"",
 			repo1,
 			branch1),
@@ -1029,7 +1029,7 @@ func TestAzureRepos_DownloadRepositoryAtCommit(t *testing.T) {
 	assert.NoError(t, err)
 	defer func() { _ = os.RemoveAll(dir) }()
 
-	_ = client.DownloadRepository(ctx, "", repo1, commitSha, dir)
+	_ = client.DownloadRepositoryByCommit(ctx, "", repo1, commitSha, dir)
 
 	// Without versionType=commit Azure reads the sha as a branch name and answers 404.
 	assert.Contains(t, gotUri, "versionDescriptor[versionType]=commit")
@@ -1055,5 +1055,6 @@ func TestAzureRepos_DownloadRepositoryAtBranchKeepsBranchVersionType(t *testing.
 
 	_ = client.DownloadRepository(ctx, "", repo1, "feat/slashed-name", dir)
 
+	assert.Contains(t, gotUri, "versionDescriptor[versionType]=branch")
 	assert.NotContains(t, gotUri, "versionType=commit")
 }

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -979,6 +979,11 @@ func TestAzureRepos_GetMergeBaseBlankParams(t *testing.T) {
 	assert.ErrorContains(t, err, "required parameter 'repository' is missing")
 }
 
+const (
+	masterSha  = "86d6919952702f9ab03bc95b45687f145a663de0"
+	featureSha = "11a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4"
+)
+
 func createAzureReposMergeBaseHandler(t *testing.T, commitsResponse []byte) createHandlerFunc {
 	mergeBase := `{"count":1,"value":[{"commitId":"86d6919952702f9ab03bc95b45687f145a663de0","author":{"name":"Test User","email":"test@myserver.com","date":"2022-11-07T10:36:41Z"},"committer":{"name":"Test User","email":"test@myserver.com","date":"2022-11-07T10:36:41Z"},"comment":"merge base"}]}`
 	return func(t *testing.T, _ string, _ []byte, _ int) http.HandlerFunc {
@@ -995,13 +1000,19 @@ func createAzureReposMergeBaseHandler(t *testing.T, commitsResponse []byte) crea
 				assert.NoError(t, err)
 				return
 			}
-			if strings.Contains(r.RequestURI, "mergebases") {
+			if strings.Contains(r.RequestURI, "mergeBases") {
 				// Azure rejects anything that is not a 40-hex object id, on BOTH sides.
-				assert.Contains(t, r.RequestURI, "/commits/86d6919952702f9ab03bc95b45687f145a663de0/mergebases")
-				assert.Contains(t, r.RequestURI, "otherCommitId=86d6919952702f9ab03bc95b45687f145a663de0")
+				// Distinct shas per side, so swapping CommitId and OtherCommitId fails the test.
+				assert.Contains(t, r.RequestURI, "/commits/"+masterSha+"/mergeBases")
+				assert.Contains(t, r.RequestURI, "otherCommitId="+featureSha)
 				assert.NotContains(t, r.RequestURI, "master")
 				assert.NotContains(t, r.RequestURI, "slashed")
 				_, err := w.Write([]byte(mergeBase))
+				assert.NoError(t, err)
+				return
+			}
+			if strings.Contains(r.RequestURI, "itemVersion.version=feat") {
+				_, err := w.Write([]byte(`{"count":1,"value":[{"commitId":"` + featureSha + `"}]}`))
 				assert.NoError(t, err)
 				return
 			}
@@ -1057,4 +1068,20 @@ func TestAzureRepos_DownloadRepositoryAtBranchKeepsBranchVersionType(t *testing.
 
 	assert.Contains(t, gotUri, "versionDescriptor[versionType]=branch")
 	assert.NotContains(t, gotUri, "versionType=commit")
+}
+
+func TestAzureRepos_DownloadRepositoryTransportErrorDoesNotPanic(t *testing.T) {
+	client, err := NewClientBuilder(vcsutils.AzureRepos).ApiEndpoint("http://127.0.0.1:8081").Token(token).Project(project).Build()
+	assert.NoError(t, err)
+	dir, err := os.MkdirTemp("", "")
+	assert.NoError(t, err)
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	assert.NotPanics(t, func() {
+		err = client.DownloadRepository(ctx, "", repo1, branch1, dir)
+	})
+	assert.Error(t, err)
 }

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/webapi"
 	"github.com/stretchr/testify/assert"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1007,4 +1008,51 @@ func createAzureReposMergeBaseHandler(t *testing.T, commitsResponse []byte) crea
 			assert.NoError(t, err)
 		}
 	}
+}
+
+func TestAzureRepos_DownloadRepositoryAtCommit(t *testing.T) {
+	ctx := context.Background()
+	const commitSha = "be8b434506dfe97e27e7d8f35d3320b881ddb5c2"
+	var gotUri string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "items/items") {
+			gotUri = r.RequestURI
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewClientBuilder(vcsutils.AzureRepos).ApiEndpoint(server.URL).Token(token).Project(project).Build()
+	assert.NoError(t, err)
+	dir, err := os.MkdirTemp("", "")
+	assert.NoError(t, err)
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	_ = client.DownloadRepository(ctx, "", repo1, commitSha, dir)
+
+	// Without versionType=commit Azure reads the sha as a branch name and answers 404.
+	assert.Contains(t, gotUri, "versionDescriptor[versionType]=commit")
+	assert.Contains(t, gotUri, "versionDescriptor[version]="+commitSha)
+}
+
+func TestAzureRepos_DownloadRepositoryAtBranchKeepsBranchVersionType(t *testing.T) {
+	ctx := context.Background()
+	var gotUri string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.RequestURI, "items/items") {
+			gotUri = r.RequestURI
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewClientBuilder(vcsutils.AzureRepos).ApiEndpoint(server.URL).Token(token).Project(project).Build()
+	assert.NoError(t, err)
+	dir, err := os.MkdirTemp("", "")
+	assert.NoError(t, err)
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	_ = client.DownloadRepository(ctx, "", repo1, "feat/slashed-name", dir)
+
+	assert.NotContains(t, gotUri, "versionType=commit")
 }

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -952,3 +952,59 @@ func createBadAzureReposClient(t *testing.T, response []byte) (VcsClient, func()
 		createAzureReposHandler)
 	return client, cleanUp
 }
+
+func TestAzureRepos_GetMergeBase(t *testing.T) {
+	ctx := context.Background()
+	commitsResponse, err := os.ReadFile(filepath.Join("testdata", "azurerepos", "commits.json"))
+	assert.NoError(t, err)
+
+	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, nil, "mergebases",
+		createAzureReposMergeBaseHandler(t, commitsResponse))
+	defer cleanUp()
+
+	result, err := client.GetMergeBase(ctx, "", repo1, "master", "feat/slashed-name")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "86d6919952702f9ab03bc95b45687f145a663de0", result.Hash)
+}
+
+func TestAzureRepos_GetMergeBaseBlankParams(t *testing.T) {
+	client, err := NewClientBuilder(vcsutils.AzureRepos).Build()
+	assert.NoError(t, err)
+
+	_, err = client.GetMergeBase(context.Background(), "", "", "master", "feature")
+
+	assert.ErrorContains(t, err, "required parameter 'repository' is missing")
+}
+
+func createAzureReposMergeBaseHandler(t *testing.T, commitsResponse []byte) createHandlerFunc {
+	mergeBase := `{"count":1,"value":[{"commitId":"86d6919952702f9ab03bc95b45687f145a663de0","author":{"name":"Test User","email":"test@myserver.com","date":"2022-11-07T10:36:41Z"},"committer":{"name":"Test User","email":"test@myserver.com","date":"2022-11-07T10:36:41Z"},"comment":"merge base"}]}`
+	return func(t *testing.T, _ string, _ []byte, _ int) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			switch r.RequestURI {
+			case "/_apis":
+				jsonVal, err := os.ReadFile(filepath.Join("./", "testdata", "azurerepos", "resourcesResponse.json"))
+				assert.NoError(t, err)
+				_, err = w.Write(jsonVal)
+				assert.NoError(t, err)
+				return
+			case "/_apis/ResourceAreas":
+				_, err := w.Write([]byte(`{"value": [],"count": 0}`))
+				assert.NoError(t, err)
+				return
+			}
+			if strings.Contains(r.RequestURI, "mergebases") {
+				// Azure rejects anything that is not a 40-hex object id, on BOTH sides.
+				assert.Contains(t, r.RequestURI, "/commits/86d6919952702f9ab03bc95b45687f145a663de0/mergebases")
+				assert.Contains(t, r.RequestURI, "otherCommitId=86d6919952702f9ab03bc95b45687f145a663de0")
+				assert.NotContains(t, r.RequestURI, "master")
+				assert.NotContains(t, r.RequestURI, "slashed")
+				_, err := w.Write([]byte(mergeBase))
+				assert.NoError(t, err)
+				return
+			}
+			_, err := w.Write(commitsResponse)
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/vcsclient/azurerepos_test.go
+++ b/vcsclient/azurerepos_test.go
@@ -961,7 +961,7 @@ func TestAzureRepos_GetMergeBase(t *testing.T) {
 	assert.NoError(t, err)
 
 	client, cleanUp := createServerAndClient(t, vcsutils.AzureRepos, true, nil, "mergebases",
-		createAzureReposMergeBaseHandler(t, commitsResponse))
+		createAzureReposMergeBaseHandler(commitsResponse))
 	defer cleanUp()
 
 	result, err := client.GetMergeBase(ctx, "", repo1, "master", "feat/slashed-name")
@@ -984,7 +984,7 @@ const (
 	featureSha = "11a2b3c4d5e6f708192a3b4c5d6e7f8091a2b3c4"
 )
 
-func createAzureReposMergeBaseHandler(t *testing.T, commitsResponse []byte) createHandlerFunc {
+func createAzureReposMergeBaseHandler(commitsResponse []byte) createHandlerFunc {
 	mergeBase := `{"count":1,"value":[{"commitId":"86d6919952702f9ab03bc95b45687f145a663de0","author":{"name":"Test User","email":"test@myserver.com","date":"2022-11-07T10:36:41Z"},"committer":{"name":"Test User","email":"test@myserver.com","date":"2022-11-07T10:36:41Z"},"comment":"merge base"}]}`
 	return func(t *testing.T, _ string, _ []byte, _ int) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1200,29 +1200,42 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 		}
 	}()
 
-	args := []string{"clone", "--depth", "1"}
-	if branch != "" {
-		args = append(args, "--branch", branch)
+	// Fetching the ref rather than cloning it keeps a commit SHA usable here, which "clone --branch" rejects.
+	gitCommands := [][]string{
+		{"init", "--quiet", tempDir},
+		{"-C", tempDir, "remote", "add", "origin", cloneURL},
 	}
-	args = append(args, cloneURL, tempDir)
+	if branch != "" {
+		gitCommands = append(gitCommands,
+			[]string{"-C", tempDir, "fetch", "--depth", "1", "--no-tags", "origin", branch},
+			[]string{"-C", tempDir, "checkout", "--quiet", "FETCH_HEAD"})
+	} else {
+		gitCommands = append(gitCommands,
+			[]string{"-C", tempDir, "fetch", "--depth", "1", "--no-tags", "origin", "HEAD"},
+			[]string{"-C", tempDir, "checkout", "--quiet", "FETCH_HEAD"})
+	}
 
-	cmd := exec.CommandContext(ctx, "git", args...)
+	var gitEnv []string
 	if client.vcsInfo.Token != "" {
 		creds := base64.StdEncoding.EncodeToString([]byte("x-token-auth:" + client.vcsInfo.Token))
-		cmd.Env = append(os.Environ(),
+		gitEnv = append(os.Environ(),
 			"GIT_CONFIG_COUNT=1",
 			"GIT_CONFIG_KEY_0=http.extraHeader",
 			fmt.Sprintf("GIT_CONFIG_VALUE_0=Authorization: Basic %s", creds),
 		)
 	}
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	if err = cmd.Run(); err != nil {
-		stderrStr := stderr.String()
-		if client.vcsInfo.Token != "" {
-			stderrStr = strings.ReplaceAll(stderrStr, client.vcsInfo.Token, "***")
+	for _, args := range gitCommands {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Env = gitEnv
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		if err = cmd.Run(); err != nil {
+			stderrStr := stderr.String()
+			if client.vcsInfo.Token != "" {
+				stderrStr = strings.ReplaceAll(stderrStr, client.vcsInfo.Token, "***")
+			}
+			return fmt.Errorf("git clone failed: %w, stderr: %s", err, stderrStr)
 		}
-		return fmt.Errorf("git clone failed: %w, stderr: %s", err, stderrStr)
 	}
 	client.logger.Info(repository, vcsutils.SuccessfulRepoDownload)
 
@@ -1241,7 +1254,50 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 	return vcsutils.CreateDotGitFolderWithRemote(localPath, "origin", repositoryInfo.CloneInfo.HTTP)
 }
 
-// GetMergeBase on Bitbucket Cloud
-func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	return CommitInfo{}, ErrMergeBaseUnsupported
+// GetMergeBase on Bitbucket cloud
+func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
+	if err = validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
+		return
+	}
+
+	apiBaseUrl := bitbucketCloudApiBaseUrl
+	if client.url != nil {
+		apiBaseUrl = strings.TrimSuffix(client.url.String(), "/")
+	}
+	requestUrl := fmt.Sprintf("%s/repositories/%s/%s/merge-base/%s..%s", apiBaseUrl, owner, repository,
+		url.PathEscape(refBefore), url.PathEscape(refAfter))
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl, nil)
+	if err != nil {
+		return
+	}
+	client.setAuthenticationHeader(request)
+
+	response, err := (&http.Client{}).Do(request)
+	if err != nil {
+		return
+	}
+	defer func() {
+		err = errors.Join(err, response.Body.Close())
+	}()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+	if response.StatusCode != http.StatusOK {
+		return CommitInfo{}, fmt.Errorf("failed to get the merge base of '%s' and '%s' in <%s/%s>, status: %s, body: %s",
+			refBefore, refAfter, owner, repository, response.Status, body)
+	}
+
+	var mergeBase commitDetails
+	if err = json.Unmarshal(body, &mergeBase); err != nil {
+		return
+	}
+	return mapBitbucketCloudCommitToCommitInfo(mergeBase), nil
 }

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -903,7 +903,9 @@ func (client *BitbucketCloudClient) GetModifiedFiles(ctx context.Context, owner,
 		// As there is no `topic` set it will be treated as `refAfter...refBefore` actually.
 		Spec:    refAfter + ".." + refBefore,
 		Renames: true,
-		Merge:   true,
+		// Merge is deprecated in favour of Topic, but setting it true emits no parameter at all, while
+		// dropping it would send merge=false and Topic would send topic=true. Both change the request.
+		Merge: true, //nolint:staticcheck
 	}
 
 	fileNamesSet := datastructures.MakeSet[string]()

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1240,3 +1240,8 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 	}
 	return vcsutils.CreateDotGitFolderWithRemote(localPath, "origin", repositoryInfo.CloneInfo.HTTP)
 }
+
+// GetMergeBase on Bitbucket Cloud
+func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
+	return CommitInfo{}, ErrMergeBaseUnsupported
+}

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1287,3 +1287,8 @@ func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, rep
 	}
 	return mapBitbucketCloudCommitToCommitInfo(mergeBase), nil
 }
+
+// DownloadRepositoryByCommit on Bitbucket cloud
+func (client *BitbucketCloudClient) DownloadRepositoryByCommit(ctx context.Context, owner, repository, commitSha, localPath string) error {
+	return client.DownloadRepository(ctx, owner, repository, commitSha, localPath)
+}

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1300,5 +1300,8 @@ func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, rep
 	if err = json.Unmarshal(body, &mergeBase); err != nil {
 		return
 	}
+	if mergeBase.Hash == "" {
+		return CommitInfo{}, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+	}
 	return mapBitbucketCloudCommitToCommitInfo(mergeBase), nil
 }

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1188,8 +1188,30 @@ func splitBitbucketCloudRepoName(name string) (string, string) {
 // Clones the repository using git with x-token-auth authentication.
 // This is a workaround for BCLOUD-23783: Bitbucket Cloud archive downloads do not support Bearer
 // token auth. Remove this fallback once Atlassian resolves BCLOUD-23783.
-func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Context, owner, repository, branch, localPath string) (err error) {
-	client.logger.Debug("Using git clone fallback (BCLOUD-23783 workaround: Bearer tokens not supported for archive downloads)")
+func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Context, owner, repository, branch, localPath string) error {
+	args := []string{"clone", "--depth", "1"}
+	if branch != "" {
+		args = append(args, "--branch", branch)
+	}
+	return client.downloadRepositoryViaGit(ctx, owner, repository, localPath, func(cloneURL, tempDir string) [][]string {
+		return [][]string{append(args, cloneURL, tempDir)}
+	})
+}
+
+// A commit SHA is not a valid argument for "clone --branch", so it is fetched into an initialized repository instead.
+func (client *BitbucketCloudClient) downloadRepositoryCommitViaGitFetch(ctx context.Context, owner, repository, commitSha, localPath string) error {
+	return client.downloadRepositoryViaGit(ctx, owner, repository, localPath, func(cloneURL, tempDir string) [][]string {
+		return [][]string{
+			{"init", "--quiet", tempDir},
+			{"-C", tempDir, "remote", "add", "origin", cloneURL},
+			{"-C", tempDir, "fetch", "--depth", "1", "--no-tags", "origin", commitSha},
+			{"-C", tempDir, "checkout", "--quiet", "FETCH_HEAD"},
+		}
+	})
+}
+
+func (client *BitbucketCloudClient) downloadRepositoryViaGit(ctx context.Context, owner, repository, localPath string, buildGitCommands func(cloneURL, tempDir string) [][]string) (err error) {
+	client.logger.Debug("Using git fallback (BCLOUD-23783 workaround: Bearer tokens not supported for archive downloads)")
 	cloneURL := fmt.Sprintf("https://bitbucket.org/%s/%s.git", owner, repository)
 
 	tempDir, err := os.MkdirTemp("", "bitbucket-clone-*")
@@ -1202,18 +1224,6 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 		}
 	}()
 
-	// Fetching the ref rather than cloning it keeps a commit SHA usable here, which "clone --branch" rejects.
-	ref := branch
-	if ref == "" {
-		ref = "HEAD"
-	}
-	gitCommands := [][]string{
-		{"init", "--quiet", tempDir},
-		{"-C", tempDir, "remote", "add", "origin", cloneURL},
-		{"-C", tempDir, "fetch", "--depth", "1", "--no-tags", "origin", ref},
-		{"-C", tempDir, "checkout", "--quiet", "FETCH_HEAD"},
-	}
-
 	var gitEnv []string
 	if client.vcsInfo.Token != "" {
 		creds := base64.StdEncoding.EncodeToString([]byte("x-token-auth:" + client.vcsInfo.Token))
@@ -1223,7 +1233,7 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 			fmt.Sprintf("GIT_CONFIG_VALUE_0=Authorization: Basic %s", creds),
 		)
 	}
-	for _, args := range gitCommands {
+	for _, args := range buildGitCommands(cloneURL, tempDir) {
 		cmd := exec.CommandContext(ctx, "git", args...)
 		cmd.Env = gitEnv
 		var stderr bytes.Buffer
@@ -1292,5 +1302,8 @@ func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, rep
 
 // DownloadRepositoryByCommit on Bitbucket cloud
 func (client *BitbucketCloudClient) DownloadRepositoryByCommit(ctx context.Context, owner, repository, commitSha, localPath string) error {
+	if client.vcsInfo.Username == "" && client.vcsInfo.Token != "" {
+		return client.downloadRepositoryCommitViaGitFetch(ctx, owner, repository, commitSha, localPath)
+	}
 	return client.DownloadRepository(ctx, owner, repository, commitSha, localPath)
 }

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1253,12 +1253,7 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 
 // GetMergeBase on Bitbucket cloud
 func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
-	if err = validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err = validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
 		return
 	}
 
@@ -1273,27 +1268,9 @@ func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, rep
 	if err != nil {
 		return
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl, nil)
+	body, err := getBitbucketJson(ctx, bitbucketClient.HttpClient, requestUrl, client.setAuthenticationHeader)
 	if err != nil {
 		return
-	}
-	client.setAuthenticationHeader(request)
-
-	response, err := bitbucketClient.HttpClient.Do(request)
-	if err != nil {
-		return
-	}
-	defer func() {
-		err = errors.Join(err, response.Body.Close())
-	}()
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return
-	}
-	if response.StatusCode != http.StatusOK {
-		return CommitInfo{}, fmt.Errorf("failed to get the merge base of '%s' and '%s' in <%s/%s>, status: %s, body: %s",
-			refBefore, refAfter, owner, repository, response.Status, body)
 	}
 
 	var mergeBase commitDetails
@@ -1301,7 +1278,7 @@ func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, rep
 		return
 	}
 	if mergeBase.Hash == "" {
-		return CommitInfo{}, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+		return CommitInfo{}, mergeBaseNotFoundError(owner, repository, refBefore, refAfter)
 	}
 	return mapBitbucketCloudCommitToCommitInfo(mergeBase), nil
 }

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1201,18 +1201,15 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 	}()
 
 	// Fetching the ref rather than cloning it keeps a commit SHA usable here, which "clone --branch" rejects.
+	ref := branch
+	if ref == "" {
+		ref = "HEAD"
+	}
 	gitCommands := [][]string{
 		{"init", "--quiet", tempDir},
 		{"-C", tempDir, "remote", "add", "origin", cloneURL},
-	}
-	if branch != "" {
-		gitCommands = append(gitCommands,
-			[]string{"-C", tempDir, "fetch", "--depth", "1", "--no-tags", "origin", branch},
-			[]string{"-C", tempDir, "checkout", "--quiet", "FETCH_HEAD"})
-	} else {
-		gitCommands = append(gitCommands,
-			[]string{"-C", tempDir, "fetch", "--depth", "1", "--no-tags", "origin", "HEAD"},
-			[]string{"-C", tempDir, "checkout", "--quiet", "FETCH_HEAD"})
+		{"-C", tempDir, "fetch", "--depth", "1", "--no-tags", "origin", ref},
+		{"-C", tempDir, "checkout", "--quiet", "FETCH_HEAD"},
 	}
 
 	var gitEnv []string
@@ -1234,7 +1231,7 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 			if client.vcsInfo.Token != "" {
 				stderrStr = strings.ReplaceAll(stderrStr, client.vcsInfo.Token, "***")
 			}
-			return fmt.Errorf("git clone failed: %w, stderr: %s", err, stderrStr)
+			return fmt.Errorf("git %s failed: %w, stderr: %s", args[0], err, stderrStr)
 		}
 	}
 	client.logger.Info(repository, vcsutils.SuccessfulRepoDownload)
@@ -1272,13 +1269,17 @@ func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, rep
 	requestUrl := fmt.Sprintf("%s/repositories/%s/%s/merge-base/%s..%s", apiBaseUrl, owner, repository,
 		url.PathEscape(refBefore), url.PathEscape(refAfter))
 
+	bitbucketClient, err := client.buildBitbucketCloudClient(ctx)
+	if err != nil {
+		return
+	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl, nil)
 	if err != nil {
 		return
 	}
 	client.setAuthenticationHeader(request)
 
-	response, err := (&http.Client{}).Do(request)
+	response, err := bitbucketClient.HttpClient.Do(request)
 	if err != nil {
 		return
 	}

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1253,12 +1253,12 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 
 // GetMergeBase on Bitbucket cloud
 func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
-	if err = validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err = errors.Join(
+		validateNotBlank("owner", owner),
+		validateNotBlank("repository", repository),
+		validateNotBlank("refBefore", refBefore),
+		validateNotBlank("refAfter", refAfter),
+	); err != nil {
 		return
 	}
 

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -1253,7 +1253,12 @@ func (client *BitbucketCloudClient) downloadRepositoryViaGitClone(ctx context.Co
 
 // GetMergeBase on Bitbucket cloud
 func (client *BitbucketCloudClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
-	if err = validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
+	if err = validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
 		return
 	}
 

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -181,7 +181,34 @@ func TestBitbucketCloud_DownloadRepository_BearerToken_RoutesToGitClone(t *testi
 
 	err = client.DownloadRepository(ctx, owner, repo1, branch1, dir)
 	assert.Error(t, err)
-	assert.Regexp(t, `^git \w+ failed`, err.Error(), "error should originate from the git path, not the archive download path")
+	assert.Contains(t, err.Error(), "git clone failed", "a branch must still be downloaded with git clone")
+	assert.False(t, archiveEndpointCalled, "archive HTTP endpoint must not be called when no username is set")
+}
+
+func TestBitbucketCloud_DownloadRepositoryByCommit_BearerToken_RoutesToGitFetch(t *testing.T) {
+	archiveEndpointCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		archiveEndpointCalled = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).
+		ApiEndpoint(server.URL).
+		Token(token).
+		Build()
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	dir, err := os.MkdirTemp("", "")
+	assert.NoError(t, err)
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	err = client.DownloadRepositoryByCommit(ctx, owner, repo1, "d1c1e8e0e0b5bd1e8e0e0b5bd1e8e0e0b5bd1e8e", dir)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "git init failed", "a commit sha must be downloaded with git fetch, which starts by initializing a repository")
 	assert.False(t, archiveEndpointCalled, "archive HTTP endpoint must not be called when no username is set")
 }
 

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -910,3 +910,28 @@ func createBitbucketCloudHandler(t *testing.T, expectedURI string, response []by
 		assert.Equal(t, basicAuthHeader, r.Header.Get("Authorization"))
 	}
 }
+
+func TestBitbucketCloud_GetMergeBase(t *testing.T) {
+	ctx := context.Background()
+	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud", "merge_base.json"))
+	assert.NoError(t, err)
+
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketCloud, true, response,
+		"/repositories/jfrog/repo-1/merge-base/master..feat%2Fslashed-name", createBitbucketCloudHandler)
+	defer cleanUp()
+
+	result, err := client.GetMergeBase(ctx, "jfrog", "repo-1", "master", "feat/slashed-name")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "93983fd5cfad48aae91480c6db0dee1caa5dc4e1", result.Hash)
+	assert.Equal(t, "Albert Sundjaja", result.AuthorName)
+}
+
+func TestBitbucketCloud_GetMergeBaseBlankParams(t *testing.T) {
+	client, err := NewClientBuilder(vcsutils.BitbucketCloud).Build()
+	assert.NoError(t, err)
+
+	_, err = client.GetMergeBase(context.Background(), "jfrog", "", "master", "feature")
+
+	assert.ErrorContains(t, err, "required parameter 'repository' is missing")
+}

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -181,7 +181,7 @@ func TestBitbucketCloud_DownloadRepository_BearerToken_RoutesToGitClone(t *testi
 
 	err = client.DownloadRepository(ctx, owner, repo1, branch1, dir)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "git clone failed", "error should originate from the git clone path, not the archive download path")
+	assert.Regexp(t, `^git \w+ failed`, err.Error(), "error should originate from the git path, not the archive download path")
 	assert.False(t, archiveEndpointCalled, "archive HTTP endpoint must not be called when no username is set")
 }
 

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -10,6 +10,7 @@ import (
 const (
 	notSupportedOnBitbucket     = "currently not supported on Bitbucket"
 	bitbucketPrContentSizeLimit = 32768
+	bitbucketCloudApiBaseUrl    = "https://api.bitbucket.org/2.0"
 )
 
 var (

--- a/vcsclient/bitbucketcommon.go
+++ b/vcsclient/bitbucketcommon.go
@@ -1,10 +1,15 @@
 package vcsclient
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"time"
+
 	"github.com/jfrog/froggit-go/vcsutils"
 	"github.com/mitchellh/mapstructure"
-	"time"
 )
 
 const (
@@ -129,4 +134,29 @@ func getBitbucketCloudCommitStatusInfo(commitStatus *BitbucketCommitInfo) (Commi
 		CreatedAt:     createdOn,
 		LastUpdatedAt: updatedOn,
 	}, nil
+}
+
+// getBitbucketJson issues an authenticated GET and returns the response body, shared by both Bitbucket clients.
+func getBitbucketJson(ctx context.Context, httpClient *http.Client, requestUrl string, setAuth func(*http.Request)) (body []byte, err error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl, nil)
+	if err != nil {
+		return
+	}
+	if setAuth != nil {
+		setAuth(request)
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return
+	}
+	defer func() {
+		err = errors.Join(err, response.Body.Close())
+	}()
+	if body, err = io.ReadAll(response.Body); err != nil {
+		return
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("request to %s returned status %s, body: %s", requestUrl, response.Status, body)
+	}
+	return
 }

--- a/vcsclient/bitbucketcommon_test.go
+++ b/vcsclient/bitbucketcommon_test.go
@@ -1,9 +1,10 @@
 package vcsclient
 
 import (
-	"github.com/jfrog/froggit-go/vcsutils"
 	"testing"
 	"time"
+
+	"github.com/jfrog/froggit-go/vcsutils"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -990,12 +990,12 @@ func getSourceRepositoryOwner(pullRequest bitbucketv1.PullRequest) (string, erro
 
 // GetMergeBase on Bitbucket server
 func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
-	if err = validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err = errors.Join(
+		validateNotBlank("owner", owner),
+		validateNotBlank("repository", repository),
+		validateNotBlank("refBefore", refBefore),
+		validateNotBlank("refAfter", refAfter),
+	); err != nil {
 		return
 	}
 

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -990,7 +990,12 @@ func getSourceRepositoryOwner(pullRequest bitbucketv1.PullRequest) (string, erro
 
 // GetMergeBase on Bitbucket server
 func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
-	if err = validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
+	if err = validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
 		return
 	}
 

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -986,3 +986,8 @@ func getSourceRepositoryOwner(pullRequest bitbucketv1.PullRequest) (string, erro
 	}
 	return project.Key, nil
 }
+
+// GetMergeBase on Bitbucket Server
+func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
+	return CommitInfo{}, ErrMergeBaseUnsupported
+}

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -1027,3 +1027,8 @@ func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, re
 	}
 	return client.mapBitbucketServerCommitToCommitInfo(mergeBase, owner, repository), nil
 }
+
+// DownloadRepositoryByCommit on Bitbucket server
+func (client *BitbucketServerClient) DownloadRepositoryByCommit(ctx context.Context, owner, repository, commitSha, localPath string) error {
+	return client.DownloadRepository(ctx, owner, repository, commitSha, localPath)
+}

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -987,7 +988,55 @@ func getSourceRepositoryOwner(pullRequest bitbucketv1.PullRequest) (string, erro
 	return project.Key, nil
 }
 
-// GetMergeBase on Bitbucket Server
-func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	return CommitInfo{}, ErrMergeBaseUnsupported
+// GetMergeBase on Bitbucket server
+func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
+	if err = validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
+		return
+	}
+
+	// The path segment accepts only a commit id: a slashed branch name resolves to a different route
+	// and its encoded form is rejected before it reaches the application.
+	baseCommit, err := client.GetLatestCommit(ctx, owner, repository, refBefore)
+	if err != nil {
+		return
+	}
+	if baseCommit.Hash == "" {
+		return CommitInfo{}, fmt.Errorf("could not resolve reference '%s' to a commit in <%s/%s>", refBefore, owner, repository)
+	}
+
+	restEndpoint := strings.TrimSuffix(client.vcsInfo.APIEndpoint, "/rest") + "/rest"
+	requestUrl := fmt.Sprintf("%s/api/1.0/projects/%s/repos/%s/commits/%s/merge-base?otherCommitId=%s",
+		restEndpoint, owner, repository, baseCommit.Hash, url.QueryEscape(refAfter))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl, nil)
+	if err != nil {
+		return
+	}
+	response, err := client.buildHTTPClient(ctx).Do(req)
+	if err != nil {
+		return
+	}
+	defer func() {
+		err = errors.Join(err, response.Body.Close())
+	}()
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return
+	}
+	if response.StatusCode >= 300 {
+		return CommitInfo{}, fmt.Errorf("failed to get the merge base of '%s' and '%s' in <%s/%s>, status: %s, body: %s",
+			refBefore, refAfter, owner, repository, response.Status, body)
+	}
+
+	var mergeBase bitbucketv1.Commit
+	if err = json.Unmarshal(body, &mergeBase); err != nil {
+		return
+	}
+	return client.mapBitbucketServerCommitToCommitInfo(mergeBase, owner, repository), nil
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -990,12 +990,7 @@ func getSourceRepositoryOwner(pullRequest bitbucketv1.PullRequest) (string, erro
 
 // GetMergeBase on Bitbucket server
 func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (commitInfo CommitInfo, err error) {
-	if err = validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err = validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
 		return
 	}
 
@@ -1013,25 +1008,9 @@ func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, re
 	requestUrl := fmt.Sprintf("%s/api/1.0/projects/%s/repos/%s/commits/%s/merge-base?otherCommitId=%s",
 		restEndpoint, owner, repository, baseCommit.Hash, url.QueryEscape(refAfter))
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, requestUrl, nil)
+	body, err := getBitbucketJson(ctx, client.buildHTTPClient(ctx), requestUrl, nil)
 	if err != nil {
 		return
-	}
-	response, err := client.buildHTTPClient(ctx).Do(req)
-	if err != nil {
-		return
-	}
-	defer func() {
-		err = errors.Join(err, response.Body.Close())
-	}()
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return
-	}
-	if response.StatusCode >= 300 {
-		return CommitInfo{}, fmt.Errorf("failed to get the merge base of '%s' and '%s' in <%s/%s>, status: %s, body: %s",
-			refBefore, refAfter, owner, repository, response.Status, body)
 	}
 
 	var mergeBase bitbucketv1.Commit
@@ -1039,7 +1018,7 @@ func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, re
 		return
 	}
 	if mergeBase.ID == "" {
-		return CommitInfo{}, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+		return CommitInfo{}, mergeBaseNotFoundError(owner, repository, refBefore, refAfter)
 	}
 	return client.mapBitbucketServerCommitToCommitInfo(mergeBase, owner, repository), nil
 }

--- a/vcsclient/bitbucketserver.go
+++ b/vcsclient/bitbucketserver.go
@@ -1038,5 +1038,8 @@ func (client *BitbucketServerClient) GetMergeBase(ctx context.Context, owner, re
 	if err = json.Unmarshal(body, &mergeBase); err != nil {
 		return
 	}
+	if mergeBase.ID == "" {
+		return CommitInfo{}, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+	}
 	return client.mapBitbucketServerCommitToCommitInfo(mergeBase, owner, repository), nil
 }

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -1055,7 +1055,7 @@ func TestBitbucketServer_GetMergeBase(t *testing.T) {
 	assert.NoError(t, err)
 
 	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, false, mergeBaseResponse, "",
-		createBitbucketServerMergeBaseHandler(t, commitsResponse))
+		createBitbucketServerMergeBaseHandler(commitsResponse))
 	defer cleanUp()
 
 	result, err := client.GetMergeBase(ctx, owner, repo1, "master", "feature/slashed-name")
@@ -1074,7 +1074,7 @@ func TestBitbucketServer_GetMergeBaseBlankParams(t *testing.T) {
 	assert.ErrorContains(t, err, "required parameter 'repository' is missing")
 }
 
-func createBitbucketServerMergeBaseHandler(t *testing.T, commitsResponse []byte) createHandlerFunc {
+func createBitbucketServerMergeBaseHandler(commitsResponse []byte) createHandlerFunc {
 	return func(t *testing.T, _ string, response []byte, expectedStatusCode int) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(r.RequestURI, "/merge-base") {

--- a/vcsclient/bitbucketserver_test.go
+++ b/vcsclient/bitbucketserver_test.go
@@ -1046,3 +1046,50 @@ func TestGetCommitsInDateRate(t *testing.T) {
 		})
 	}
 }
+
+func TestBitbucketServer_GetMergeBase(t *testing.T) {
+	ctx := context.Background()
+	mergeBaseResponse, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver", "commit_single_response.json"))
+	assert.NoError(t, err)
+	commitsResponse, err := os.ReadFile(filepath.Join("testdata", "bitbucketserver", "commit_list_response.json"))
+	assert.NoError(t, err)
+
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketServer, false, mergeBaseResponse, "",
+		createBitbucketServerMergeBaseHandler(t, commitsResponse))
+	defer cleanUp()
+
+	result, err := client.GetMergeBase(ctx, owner, repo1, "master", "feature/slashed-name")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "abcdef0123abcdef4567abcdef8987abcdef6543", result.Hash)
+	assert.Equal(t, "charlie", result.AuthorName)
+}
+
+func TestBitbucketServer_GetMergeBaseBlankParams(t *testing.T) {
+	client, err := NewClientBuilder(vcsutils.BitbucketServer).Build()
+	assert.NoError(t, err)
+
+	_, err = client.GetMergeBase(context.Background(), owner, "", "master", "feature")
+
+	assert.ErrorContains(t, err, "required parameter 'repository' is missing")
+}
+
+func createBitbucketServerMergeBaseHandler(t *testing.T, commitsResponse []byte) createHandlerFunc {
+	return func(t *testing.T, _ string, response []byte, expectedStatusCode int) http.HandlerFunc {
+		return func(w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(r.RequestURI, "/merge-base") {
+				// The path segment must be the resolved commit id: Tomcat rejects encoded slashes.
+				assert.Contains(t, r.RequestURI, "/commits/def0123abcdef4567abcdef8987abcdef6543abc/merge-base")
+				assert.Contains(t, r.RequestURI, "otherCommitId=feature%2Fslashed-name")
+				assert.NotContains(t, r.RequestURI, "/commits/master/")
+				w.WriteHeader(expectedStatusCode)
+				_, err := w.Write(response)
+				assert.NoError(t, err)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write(commitsResponse)
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1923,3 +1923,8 @@ func (client *GitHubClient) GetMergeBase(ctx context.Context, owner, repository,
 	})
 	return mergeBase, err
 }
+
+// DownloadRepositoryByCommit on GitHub
+func (client *GitHubClient) DownloadRepositoryByCommit(ctx context.Context, owner, repository, commitSha, localPath string) error {
+	return client.DownloadRepository(ctx, owner, repository, commitSha, localPath)
+}

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1896,12 +1896,12 @@ func convertToGitHubSnapshot(snapshot *SbomSnapshot) (*github.DependencyGraphSna
 
 // GetMergeBase on GitHub
 func (client *GitHubClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	if err := validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err := errors.Join(
+		validateNotBlank("owner", owner),
+		validateNotBlank("repository", repository),
+		validateNotBlank("refBefore", refBefore),
+		validateNotBlank("refAfter", refAfter),
+	); err != nil {
 		return CommitInfo{}, err
 	}
 

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1893,3 +1893,8 @@ func convertToGitHubSnapshot(snapshot *SbomSnapshot) (*github.DependencyGraphSna
 	}
 	return ghSnapshot, nil
 }
+
+// GetMergeBase on GitHub
+func (client *GitHubClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
+	return CommitInfo{}, ErrMergeBaseUnsupported
+}

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1896,5 +1896,30 @@ func convertToGitHubSnapshot(snapshot *SbomSnapshot) (*github.DependencyGraphSna
 
 // GetMergeBase on GitHub
 func (client *GitHubClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	return CommitInfo{}, ErrMergeBaseUnsupported
+	if err := validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
+		return CommitInfo{}, err
+	}
+
+	var mergeBase CommitInfo
+	err := client.runWithRateLimitRetries(func() (*github.Response, error) {
+		comparison, ghResponse, err := client.ghClient.Repositories.CompareCommits(ctx, owner, repository,
+			refBefore, refAfter, &github.ListOptions{PerPage: 1})
+		if err != nil {
+			return ghResponse, err
+		}
+		if err = vcsutils.CheckResponseStatusWithBody(ghResponse.Response, http.StatusOK); err != nil {
+			return ghResponse, err
+		}
+		if comparison.MergeBaseCommit == nil {
+			return ghResponse, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+		}
+		mergeBase = mapGitHubCommitToCommitInfo(comparison.MergeBaseCommit)
+		return ghResponse, nil
+	})
+	return mergeBase, err
 }

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1896,12 +1896,7 @@ func convertToGitHubSnapshot(snapshot *SbomSnapshot) (*github.DependencyGraphSna
 
 // GetMergeBase on GitHub
 func (client *GitHubClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	if err := validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err := validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
 		return CommitInfo{}, err
 	}
 
@@ -1916,7 +1911,7 @@ func (client *GitHubClient) GetMergeBase(ctx context.Context, owner, repository,
 			return ghResponse, err
 		}
 		if comparison.MergeBaseCommit == nil {
-			return ghResponse, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+			return ghResponse, mergeBaseNotFoundError(owner, repository, refBefore, refAfter)
 		}
 		mergeBase = mapGitHubCommitToCommitInfo(comparison.MergeBaseCommit)
 		return ghResponse, nil

--- a/vcsclient/github.go
+++ b/vcsclient/github.go
@@ -1896,7 +1896,12 @@ func convertToGitHubSnapshot(snapshot *SbomSnapshot) (*github.DependencyGraphSna
 
 // GetMergeBase on GitHub
 func (client *GitHubClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	if err := validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
+	if err := validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
 		return CommitInfo{}, err
 	}
 

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1711,7 +1711,7 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 func TestGetMergeBaseUnsupportedProviders(t *testing.T) {
 	ctx := context.Background()
 	for _, provider := range []vcsutils.VcsProvider{
-		vcsutils.GitLab, vcsutils.BitbucketCloud, vcsutils.BitbucketServer, vcsutils.AzureRepos,
+		vcsutils.BitbucketCloud, vcsutils.BitbucketServer, vcsutils.AzureRepos,
 	} {
 		t.Run(provider.String(), func(t *testing.T) {
 			client, err := NewClientBuilder(provider).Build()

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1711,7 +1711,7 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 func TestGetMergeBaseUnsupportedProviders(t *testing.T) {
 	ctx := context.Background()
 	for _, provider := range []vcsutils.VcsProvider{
-		vcsutils.BitbucketCloud, vcsutils.BitbucketServer, vcsutils.AzureRepos,
+		vcsutils.BitbucketCloud, vcsutils.AzureRepos,
 	} {
 		t.Run(provider.String(), func(t *testing.T) {
 			client, err := NewClientBuilder(provider).Build()

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1711,7 +1711,7 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 func TestGetMergeBaseUnsupportedProviders(t *testing.T) {
 	ctx := context.Background()
 	for _, provider := range []vcsutils.VcsProvider{
-		vcsutils.BitbucketCloud, vcsutils.AzureRepos,
+		vcsutils.AzureRepos,
 	} {
 		t.Run(provider.String(), func(t *testing.T) {
 			client, err := NewClientBuilder(provider).Build()

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1707,3 +1707,19 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 	err = createBadGitHubClient(t).UploadSnapshotToDependencyGraph(ctx, owner, repo1, &snapshot)
 	assert.Error(t, err)
 }
+
+func TestGetMergeBaseUnsupportedProviders(t *testing.T) {
+	ctx := context.Background()
+	for _, provider := range []vcsutils.VcsProvider{
+		vcsutils.GitLab, vcsutils.BitbucketCloud, vcsutils.BitbucketServer, vcsutils.AzureRepos,
+	} {
+		t.Run(provider.String(), func(t *testing.T) {
+			client, err := NewClientBuilder(provider).Build()
+			assert.NoError(t, err)
+
+			_, err = client.GetMergeBase(ctx, owner, repo1, "master", "feature")
+
+			assert.ErrorIs(t, err, ErrMergeBaseUnsupported)
+		})
+	}
+}

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1723,3 +1723,38 @@ func TestGetMergeBaseUnsupportedProviders(t *testing.T) {
 		})
 	}
 }
+
+func TestGitHubClient_GetMergeBase(t *testing.T) {
+	ctx := context.Background()
+	response, err := os.ReadFile(filepath.Join("testdata", "github", "compare_commits.json"))
+	assert.NoError(t, err)
+
+	client, cleanUp := createServerAndClient(t, vcsutils.GitHub, false, response,
+		"/repos/jfrog/repo-1/compare/sha-1...sha-2?per_page=1", createGitHubHandler)
+	defer cleanUp()
+
+	result, err := client.GetMergeBase(ctx, "jfrog", "repo-1", "sha-1", "sha-2")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "ce1965514d711e17045b849e11105d9c095ee935", result.Hash)
+}
+
+func TestGitHubClient_GetMergeBaseBlankParams(t *testing.T) {
+	client, err := NewClientBuilder(vcsutils.GitHub).Build()
+	assert.NoError(t, err)
+
+	_, err = client.GetMergeBase(context.Background(), "", "repo-1", "sha-1", "sha-2")
+
+	assert.ErrorContains(t, err, "required parameter 'owner' is missing")
+}
+
+func TestGitHubClient_GetMergeBaseServerError(t *testing.T) {
+	client, cleanUp := createServerAndClientReturningStatus(t, vcsutils.GitHub, false, nil,
+		"/repos/jfrog/repo-1/compare/sha-1...sha-2?per_page=1", http.StatusInternalServerError, createGitHubHandler)
+	defer cleanUp()
+
+	result, err := client.GetMergeBase(context.Background(), "jfrog", "repo-1", "sha-1", "sha-2")
+
+	assert.Error(t, err)
+	assert.Empty(t, result.Hash)
+}

--- a/vcsclient/github_test.go
+++ b/vcsclient/github_test.go
@@ -1708,22 +1708,6 @@ func TestGithubClient_UploadSnapshotToDependencyGraph(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestGetMergeBaseUnsupportedProviders(t *testing.T) {
-	ctx := context.Background()
-	for _, provider := range []vcsutils.VcsProvider{
-		vcsutils.AzureRepos,
-	} {
-		t.Run(provider.String(), func(t *testing.T) {
-			client, err := NewClientBuilder(provider).Build()
-			assert.NoError(t, err)
-
-			_, err = client.GetMergeBase(ctx, owner, repo1, "master", "feature")
-
-			assert.ErrorIs(t, err, ErrMergeBaseUnsupported)
-		})
-	}
-}
-
 func TestGitHubClient_GetMergeBase(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "github", "compare_commits.json"))

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -1045,3 +1045,8 @@ func (client *GitLabClient) GetMergeBase(ctx context.Context, owner, repository,
 	}
 	return mapGitLabCommitToCommitInfo(commit), nil
 }
+
+// DownloadRepositoryByCommit on GitLab
+func (client *GitLabClient) DownloadRepositoryByCommit(ctx context.Context, owner, repository, commitSha, localPath string) error {
+	return client.DownloadRepository(ctx, owner, repository, commitSha, localPath)
+}

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -1022,3 +1022,8 @@ func mapGitLabPullRequestState(state *vcsutils.PullRequestState) *string {
 	}
 	return &stateStringValue
 }
+
+// GetMergeBase on GitLab
+func (client *GitLabClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
+	return CommitInfo{}, ErrMergeBaseUnsupported
+}

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -1025,5 +1025,23 @@ func mapGitLabPullRequestState(state *vcsutils.PullRequestState) *string {
 
 // GetMergeBase on GitLab
 func (client *GitLabClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	return CommitInfo{}, ErrMergeBaseUnsupported
+	if err := validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
+		return CommitInfo{}, err
+	}
+
+	refs := []string{refBefore, refAfter}
+	commit, _, err := client.glClient.Repositories.MergeBase(getProjectID(owner, repository),
+		&gitlab.MergeBaseOptions{Ref: &refs}, gitlab.WithContext(ctx))
+	if err != nil {
+		return CommitInfo{}, err
+	}
+	if commit == nil {
+		return CommitInfo{}, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+	}
+	return mapGitLabCommitToCommitInfo(commit), nil
 }

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -1025,7 +1025,12 @@ func mapGitLabPullRequestState(state *vcsutils.PullRequestState) *string {
 
 // GetMergeBase on GitLab
 func (client *GitLabClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	if err := validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
+	if err := validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	}); err != nil {
 		return CommitInfo{}, err
 	}
 

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -1025,12 +1025,7 @@ func mapGitLabPullRequestState(state *vcsutils.PullRequestState) *string {
 
 // GetMergeBase on GitLab
 func (client *GitLabClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	if err := validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err := validateMergeBaseParameters(owner, repository, refBefore, refAfter); err != nil {
 		return CommitInfo{}, err
 	}
 
@@ -1041,7 +1036,7 @@ func (client *GitLabClient) GetMergeBase(ctx context.Context, owner, repository,
 		return CommitInfo{}, err
 	}
 	if commit == nil {
-		return CommitInfo{}, fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+		return CommitInfo{}, mergeBaseNotFoundError(owner, repository, refBefore, refAfter)
 	}
 	return mapGitLabCommitToCommitInfo(commit), nil
 }

--- a/vcsclient/gitlab.go
+++ b/vcsclient/gitlab.go
@@ -1025,12 +1025,12 @@ func mapGitLabPullRequestState(state *vcsutils.PullRequestState) *string {
 
 // GetMergeBase on GitLab
 func (client *GitLabClient) GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error) {
-	if err := validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	}); err != nil {
+	if err := errors.Join(
+		validateNotBlank("owner", owner),
+		validateNotBlank("repository", repository),
+		validateNotBlank("refBefore", refBefore),
+		validateNotBlank("refAfter", refAfter),
+	); err != nil {
 		return CommitInfo{}, err
 	}
 

--- a/vcsclient/gitlab_test.go
+++ b/vcsclient/gitlab_test.go
@@ -1072,3 +1072,29 @@ func TestGitLabClient_ListPullRequestsAssociatedWithCommit(t *testing.T) {
 	assert.Equal(t, repo1, result[0].Target.Repository)
 	assert.Equal(t, owner, result[0].Target.Owner)
 }
+
+func TestGitLabClient_GetMergeBase(t *testing.T) {
+	ctx := context.Background()
+	response, err := os.ReadFile(filepath.Join("testdata", "gitlab", "merge_base.json"))
+	assert.NoError(t, err)
+
+	client, cleanUp := createServerAndClient(t, vcsutils.GitLab, false, response,
+		fmt.Sprintf("/api/v4/projects/%s/repository/merge_base?refs%%5B%%5D=master&refs%%5B%%5D=feature",
+			url.PathEscape(owner+"/"+repo1)), createGitLabHandler)
+	defer cleanUp()
+
+	result, err := client.GetMergeBase(ctx, owner, repo1, "master", "feature")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "3cc4d81a5ccedf3e4ab76ef44fae95f002de58c1", result.Hash)
+	assert.Equal(t, "Auto Runner Releaser", result.AuthorName)
+}
+
+func TestGitLabClient_GetMergeBaseBlankParams(t *testing.T) {
+	client, err := NewClientBuilder(vcsutils.GitLab).Build()
+	assert.NoError(t, err)
+
+	_, err = client.GetMergeBase(context.Background(), owner, "", "master", "feature")
+
+	assert.ErrorContains(t, err, "required parameter 'repository' is missing")
+}

--- a/vcsclient/testdata/azurerepos/resourcesResponse.json
+++ b/vcsclient/testdata/azurerepos/resourcesResponse.json
@@ -129,7 +129,17 @@
       "minVersion": "3.2",
       "maxVersion": "7.1",
       "releasedVersion": "0.0"
+    },
+    {
+      "id": "7cf2abb6-c964-4f7e-9872-f78c66e72e9c",
+      "area": "git",
+      "resourceName": "mergeBases",
+      "routeTemplate": "{project}/_apis/{area}/repositories/{repositoryNameOrId}/commits/{commitId}/{resource}",
+      "resourceVersion": 1,
+      "minVersion": "4.1",
+      "maxVersion": "7.1",
+      "releasedVersion": "0.0"
     }
   ],
-  "count": 2
+  "count": 14
 }

--- a/vcsclient/testdata/bitbucketcloud/merge_base.json
+++ b/vcsclient/testdata/bitbucketcloud/merge_base.json
@@ -1,0 +1,97 @@
+{
+    "type": "commit",
+    "hash": "93983fd5cfad48aae91480c6db0dee1caa5dc4e1",
+    "date": "2025-09-15T00:05:31+00:00",
+    "author": {
+        "type": "author",
+        "raw": "Albert Sundjaja <asundjaja@atlassian.com>",
+        "user": {
+            "display_name": "Albert Sundjaja",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/users/%7B7177c565-3bb4-44d3-b17b-e791dfb8fed8%7D"
+                },
+                "avatar": {
+                    "href": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/initials/AS-6.png"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/%7B7177c565-3bb4-44d3-b17b-e791dfb8fed8%7D/"
+                }
+            },
+            "type": "user",
+            "uuid": "{7177c565-3bb4-44d3-b17b-e791dfb8fed8}",
+            "account_id": "712020:0f3e0dc4-4f17-4c0f-be18-c3d6dfa60987",
+            "nickname": "Albert Sundjaja"
+        }
+    },
+    "message": "NONE: update jira-release-blocker to 0.2.5\n",
+    "summary": {
+        "type": "rendered",
+        "raw": "NONE: update jira-release-blocker to 0.2.5\n",
+        "markup": "markdown",
+        "html": "<p>NONE: update jira-release-blocker to 0.2.5</p>"
+    },
+    "links": {
+        "self": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes/commit/93983fd5cfad48aae91480c6db0dee1caa5dc4e1"
+        },
+        "html": {
+            "href": "https://bitbucket.org/bitbucketpipelines/official-pipes/commits/93983fd5cfad48aae91480c6db0dee1caa5dc4e1"
+        },
+        "diff": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes/diff/93983fd5cfad48aae91480c6db0dee1caa5dc4e1"
+        },
+        "approve": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes/commit/93983fd5cfad48aae91480c6db0dee1caa5dc4e1/approve"
+        },
+        "comments": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes/commit/93983fd5cfad48aae91480c6db0dee1caa5dc4e1/comments"
+        },
+        "statuses": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes/commit/93983fd5cfad48aae91480c6db0dee1caa5dc4e1/statuses"
+        },
+        "patch": {
+            "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes/patch/93983fd5cfad48aae91480c6db0dee1caa5dc4e1"
+        }
+    },
+    "parents": [
+        {
+            "hash": "2b255a5a3c66f450b091b2d354e8a8b0882ff9cc",
+            "links": {
+                "self": {
+                    "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes/commit/2b255a5a3c66f450b091b2d354e8a8b0882ff9cc"
+                },
+                "html": {
+                    "href": "https://bitbucket.org/bitbucketpipelines/official-pipes/commits/2b255a5a3c66f450b091b2d354e8a8b0882ff9cc"
+                }
+            },
+            "type": "commit"
+        }
+    ],
+    "rendered": {
+        "message": {
+            "type": "rendered",
+            "raw": "NONE: update jira-release-blocker to 0.2.5\n",
+            "markup": "markdown",
+            "html": "<p>NONE: update jira-release-blocker to 0.2.5</p>"
+        }
+    },
+    "repository": {
+        "type": "repository",
+        "full_name": "bitbucketpipelines/official-pipes",
+        "links": {
+            "self": {
+                "href": "https://api.bitbucket.org/2.0/repositories/bitbucketpipelines/official-pipes"
+            },
+            "html": {
+                "href": "https://bitbucket.org/bitbucketpipelines/official-pipes"
+            },
+            "avatar": {
+                "href": "https://bytebucket.org/ravatar/%7B55c162b8-130a-4ceb-be30-66eeea25026b%7D?ts=2117048"
+            }
+        },
+        "name": "official-pipes",
+        "uuid": "{55c162b8-130a-4ceb-be30-66eeea25026b}"
+    },
+    "participants": []
+}

--- a/vcsclient/testdata/gitlab/merge_base.json
+++ b/vcsclient/testdata/gitlab/merge_base.json
@@ -1,0 +1,19 @@
+{
+    "id": "3cc4d81a5ccedf3e4ab76ef44fae95f002de58c1",
+    "short_id": "3cc4d81a",
+    "created_at": "2023-05-22T14:03:57.000+00:00",
+    "parent_ids": [
+        "5f440d7fbcac92d4c441b68fdbd511d2c6bdf1ea"
+    ],
+    "title": "Update CHANGELOG for v16.0.0",
+    "message": "Update CHANGELOG for v16.0.0\n",
+    "author_name": "Auto Runner Releaser",
+    "author_email": "auto-runner-releaser@gitlab.com",
+    "authored_date": "2023-05-22T14:03:57.000+00:00",
+    "committer_name": "Auto Runner Releaser",
+    "committer_email": "auto-runner-releaser@gitlab.com",
+    "committed_date": "2023-05-22T14:03:57.000+00:00",
+    "trailers": {},
+    "extended_trailers": {},
+    "web_url": "https://gitlab.com/gitlab-org/gitlab-runner/-/commit/3cc4d81a5ccedf3e4ab76ef44fae95f002de58c1"
+}

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -597,6 +597,19 @@ type FileToCommit struct {
 	Content string
 }
 
+func validateMergeBaseParameters(owner, repository, refBefore, refAfter string) error {
+	return validateParametersNotBlank(map[string]string{
+		"owner":      owner,
+		"repository": repository,
+		"refBefore":  refBefore,
+		"refAfter":   refAfter,
+	})
+}
+
+func mergeBaseNotFoundError(owner, repository, refBefore, refAfter string) error {
+	return fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
+}
+
 func validateParametersNotBlank(paramNameValueMap map[string]string) error {
 	var errorMessages []string
 	for k, v := range paramNameValueMap {

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -291,8 +291,8 @@ type VcsClient interface {
 	// GetMergeBase returns the best common ancestor of two VCS references
 	// owner      - User or organization
 	// repository - VCS repository name
-	// refBefore  - The first reference (commit SHA, branch name or tag)
-	// refAfter   - The second reference (commit SHA, branch name or tag)
+	// refBefore  - The first branch name
+	// refAfter   - The second branch name
 	GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error)
 
 	// GetCommits Gets the most recent commit of a branch
@@ -618,7 +618,7 @@ func validateNotBlank(name, value string) error {
 func validateParametersNotBlank(paramNameValueMap map[string]string) error {
 	var errorMessages []string
 	for k, v := range paramNameValueMap {
-		if strings.TrimSpace(v) == "" {
+		if validateNotBlank(k, v) != nil {
 			errorMessages = append(errorMessages, fmt.Sprintf("required parameter '%s' is missing", k))
 		}
 	}

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -608,6 +608,13 @@ func mergeBaseNotFoundError(owner, repository, refBefore, refAfter string) error
 	return fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
 }
 
+func validateNotBlank(name, value string) error {
+	if strings.TrimSpace(value) == "" {
+		return fmt.Errorf("validation failed: required parameter '%s' is missing", name)
+	}
+	return nil
+}
+
 func validateParametersNotBlank(paramNameValueMap map[string]string) error {
 	var errorMessages []string
 	for k, v := range paramNameValueMap {

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -184,6 +184,13 @@ type VcsClient interface {
 	// localPath  - Local file system path
 	DownloadRepository(ctx context.Context, owner, repository, branch, localPath string) error
 
+	// DownloadRepositoryByCommit downloads the repository at a specific commit to the given path
+	// owner      - User or organization
+	// repository - VCS repository name
+	// commitSha  - The commit to download
+	// localPath  - Local file system path
+	DownloadRepositoryByCommit(ctx context.Context, owner, repository, commitSha, localPath string) error
+
 	// CreatePullRequest Creates a pull request between 2 different branches in the same repository
 	// owner        - User or organization
 	// repository   - VCS repository name

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -2,12 +2,16 @@ package vcsclient
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/jfrog/froggit-go/vcsutils"
 )
+
+// ErrMergeBaseUnsupported is returned by GetMergeBase for providers whose merge-base API is not yet implemented
+var ErrMergeBaseUnsupported = errors.New("merge base resolution is not yet supported for this provider")
 
 // CommitStatus the status of the commit in the VCS
 type CommitStatus int
@@ -276,6 +280,13 @@ type VcsClient interface {
 	// repository - VCS repository name
 	// branch     - The name of the branch
 	GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error)
+
+	// GetMergeBase returns the best common ancestor of two VCS references
+	// owner      - User or organization
+	// repository - VCS repository name
+	// refBefore  - The first reference (commit SHA, branch name or tag)
+	// refAfter   - The second reference (commit SHA, branch name or tag)
+	GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error)
 
 	// GetCommits Gets the most recent commit of a branch
 	// owner      - User or organization

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jfrog/froggit-go/vcsutils"
 )
 
-// ErrMergeBaseUnsupported is returned by GetMergeBase for providers whose merge-base API is not yet implemented
+// ErrMergeBaseUnsupported is returned by GetMergeBase for providers that do not implement merge-base resolution
 var ErrMergeBaseUnsupported = errors.New("merge base resolution is not yet supported for this provider")
 
 // CommitStatus the status of the commit in the VCS

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -288,8 +288,7 @@ type VcsClient interface {
 	// branch     - The name of the branch
 	GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error)
 
-	// GetMergeBase returns the best common ancestor of two branches, the commit they diverged from.
-	// Branch names only: Azure Repos resolves them through an API that accepts no other reference type.
+	// GetMergeBase returns the best common ancestor of two branches, the commit they diverged from
 	// owner      - User or organization
 	// repository - VCS repository name
 	// refBefore  - Branch to compare from, typically the target branch of a pull request

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -288,11 +288,12 @@ type VcsClient interface {
 	// branch     - The name of the branch
 	GetLatestCommit(ctx context.Context, owner, repository, branch string) (CommitInfo, error)
 
-	// GetMergeBase returns the best common ancestor of two VCS references
+	// GetMergeBase returns the best common ancestor of two branches, the commit they diverged from.
+	// Branch names only: Azure Repos resolves them through an API that accepts no other reference type.
 	// owner      - User or organization
 	// repository - VCS repository name
-	// refBefore  - The first branch name
-	// refAfter   - The second branch name
+	// refBefore  - Branch to compare from, typically the target branch of a pull request
+	// refAfter   - Branch to compare to, typically the source branch of a pull request
 	GetMergeBase(ctx context.Context, owner, repository, refBefore, refAfter string) (CommitInfo, error)
 
 	// GetCommits Gets the most recent commit of a branch

--- a/vcsclient/vcsclient.go
+++ b/vcsclient/vcsclient.go
@@ -597,15 +597,6 @@ type FileToCommit struct {
 	Content string
 }
 
-func validateMergeBaseParameters(owner, repository, refBefore, refAfter string) error {
-	return validateParametersNotBlank(map[string]string{
-		"owner":      owner,
-		"repository": repository,
-		"refBefore":  refBefore,
-		"refAfter":   refAfter,
-	})
-}
-
 func mergeBaseNotFoundError(owner, repository, refBefore, refAfter string) error {
 	return fmt.Errorf("no merge base found for <%s/%s> between %s and %s", owner, repository, refBefore, refAfter)
 }


### PR DESCRIPTION
## Background

Frogbot V3 PR scans diff the source branch tip against the **target branch tip**. When a branch is behind its target, the target's already-fixed vulnerabilities get reported as new findings — on a PR that changes no dependency file. Fixing that needs the merge base, which `VcsClient` could not express.

## What changed

Adds `GetMergeBase(ctx, owner, repository, refBefore, refAfter) (CommitInfo, error)` to the `VcsClient` interface, backed by each provider's native merge-base API — no clone, no history fetch.

| Provider | Endpoint | Refs accepted directly? |
|---|---|---|
| GitHub | `Repositories.CompareCommits` → `merge_base_commit` | yes |
| GitLab | `Repositories.MergeBase` | yes |
| Bitbucket Cloud | `GET .../merge-base/{revspec}` | yes |
| Bitbucket Server | `GET .../commits/{commitId}/merge-base?otherCommitId=` | **path side must be a commit id** |
| Azure Repos | `git.GetMergeBases` | **both sides must be commit ids** |

Ref-based rather than SHA-based so it reads like `git merge-base a b`; providers that require object ids resolve internally via `GetLatestCommit`. Returns `CommitInfo` for consistency with `GetLatestCommit`. **No new dependencies** — every provider's SDK or REST surface already had what was needed.

### Two providers also gain the ability to download a commit

Resolving a merge base is useless if the target tree cannot then be fetched at that commit.

- **Azure Repos** — the download passed `versionDescriptor[version]` with no `versionType`, so Azure read a commit id as a *branch name* and answered **404**. Now sends `versionType=commit` for a 40-hex ref. Caught by a real end-to-end run, not by inspection.
- **Bitbucket Cloud** — the Bearer-token `git clone` fallback (BCLOUD-23783) ran `clone --depth 1 --branch <ref>`, and `--branch` rejects a sha. Now `init` + `fetch --depth 1 origin <ref>` + `checkout FETCH_HEAD`: `fetch` takes a branch name **and** a sha, so one uniform path with no sha-sniffing. This matters because per JFrog's docs the requested Bitbucket Cloud credential is a Bitbucket Access Token — a Bearer token with no username — so the clone path is the *documented* production path.

GitHub, GitLab and Bitbucket Server needed no download change.

### Two provider quirks worth knowing

**Bitbucket Server** takes one ref in the path and one in the query, and they are not interchangeable: a slashed branch 404s in the path, its encoded form is rejected before reaching the app, and only a commit id works — but *slashless* names do work, so a hand-test on `master`/`feature` passes and hides it while real `feature/...` branches fail. The path-side ref is therefore resolved **unconditionally**.

**Azure** rejects any non-40-hex ref on both sides with a clear error, so it fails loudly rather than subtly.

Both Bitbucket and Azure tests use a slashed branch name so the encoding stays locked in.

## How it was verified

Every provider got a **real Frogbot `scan-pull-request`** against a live server, on a branch deliberately behind its target, with a slashed source branch. In each case the before/after was: `CVE-2026-41710` on `spring-retry 2.0.12` reported on a PR that changed no `pom.xml` → after, the resolved merge base matched the server's own answer, the target tree was fetched at that commit instead of the branch tip, and the finding was gone.

| Provider | Merge base verified against | End-to-end |
|---|---|---|
| GitHub | local `git merge-base` | ✅ |
| GitLab | local `git merge-base` | ✅ |
| Bitbucket Server | server's own answer | ✅ |
| Bitbucket Cloud | local `git merge-base` | ✅ both Basic **and** Bearer/clone paths |
| Azure Repos | server's own answer | ✅ |

GitLab's and Bitbucket Cloud's fixtures are real captured responses, not hand-authored. Full `./vcsclient/` suite passes.

## Note for reviewers

`pull_request.base.sha` is **not** the merge base — it looks correct and diverged from the true merge base in 11 of 25 sampled `cli/cli` PRs. Only the compare/merge-base endpoints are authoritative.

`ErrMergeBaseUnsupported` is retained though no provider now returns it: consumers branch on it, and it keeps a graceful path for any provider added later.

The `Static-Check` failure is pre-existing and unrelated — `golangci-lint` is pinned to `latest`, which floated to v2.13.1 on 2026-08-20 and now flags a 2023-era deprecation at `bitbucketcloud.go:906`. Every PR opened since then fails the same way; PR #194 passed on 2026-07-16 with an older linter.