### PR TITLE
Update Bitbucket cloud UpdatePullRequest to properly able to close PR

### DIFF
--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -909,7 +909,7 @@ func (client *BitbucketCloudClient) GetModifiedFiles(ctx context.Context, owner,
 		// As there is no `topic` set it will be treated as `refAfter...refBefore` actually.
 		Spec:    refAfter + ".." + refBefore,
 		Renames: true,
-		Merge:   true,
+		Merge:   true, //nolint:staticcheck
 	}
 
 	fileNamesSet := datastructures.MakeSet[string]()

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -411,13 +411,15 @@ func (client *BitbucketCloudClient) UpdatePullRequest(ctx context.Context, owner
 		ID:                strconv.Itoa(prId),
 		States:            []string{*vcsutils.MapPullRequestState(&state)},
 	}
-	if state == vcsutils.Closed {
-		// Bitbucket Cloud's generic PR update endpoint doesn't accept a state change; closing a PR
-		// requires the dedicated decline endpoint.
-		_, err = bitbucketClient.Repositories.PullRequests.Decline(options)
+	if _, err = bitbucketClient.Repositories.PullRequests.Update(options); err != nil {
 		return err
 	}
-	_, err = bitbucketClient.Repositories.PullRequests.Update(options)
+	if state == vcsutils.Closed {
+		// Bitbucket Cloud's generic PR update endpoint doesn't accept a state change, and its decline
+		// endpoint ignores metadata fields in its own request body - so applying both the metadata
+		// update and the state change requires both calls.
+		_, err = bitbucketClient.Repositories.PullRequests.Decline(options)
+	}
 	return err
 }
 

--- a/vcsclient/bitbucketcloud.go
+++ b/vcsclient/bitbucketcloud.go
@@ -411,6 +411,12 @@ func (client *BitbucketCloudClient) UpdatePullRequest(ctx context.Context, owner
 		ID:                strconv.Itoa(prId),
 		States:            []string{*vcsutils.MapPullRequestState(&state)},
 	}
+	if state == vcsutils.Closed {
+		// Bitbucket Cloud's generic PR update endpoint doesn't accept a state change; closing a PR
+		// requires the dedicated decline endpoint.
+		_, err = bitbucketClient.Repositories.PullRequests.Decline(options)
+		return err
+	}
 	_, err = bitbucketClient.Repositories.PullRequests.Update(options)
 	return err
 }

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -222,14 +222,25 @@ func TestBitbucketCloudClient_UpdatePullRequest(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestBitbucketCloudClient_UpdatePullRequest_ClosedUsesDeclineEndpoint(t *testing.T) {
+func TestBitbucketCloudClient_UpdatePullRequest_ClosedUpdatesThenDeclines(t *testing.T) {
 	ctx := context.Background()
 	prId := 3
-	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketCloud, true, nil, fmt.Sprintf("/repositories/jfrog/repo-1/pullrequests/%v/decline", prId), createBitbucketCloudHandler)
-	defer cleanUp()
+	updateURI := fmt.Sprintf("/repositories/jfrog/repo-1/pullrequests/%v", prId)
+	declineURI := updateURI + "/decline"
+	var requestedURIs []string
 
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedURIs = append(requestedURIs, r.RequestURI)
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("{}"))
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := buildClient(t, vcsutils.BitbucketCloud, true, server)
 	err := client.UpdatePullRequest(ctx, owner, repo1, "PR title", "PR body", "master", prId, vcsutils.Closed)
 	assert.NoError(t, err)
+	assert.Equal(t, []string{updateURI, declineURI}, requestedURIs, "expected UpdatePullRequest(Closed) to update metadata first and only then decline")
 }
 
 func TestBitbucketCloud_ListOpenPullRequests(t *testing.T) {

--- a/vcsclient/bitbucketcloud_test.go
+++ b/vcsclient/bitbucketcloud_test.go
@@ -222,6 +222,16 @@ func TestBitbucketCloudClient_UpdatePullRequest(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestBitbucketCloudClient_UpdatePullRequest_ClosedUsesDeclineEndpoint(t *testing.T) {
+	ctx := context.Background()
+	prId := 3
+	client, cleanUp := createServerAndClient(t, vcsutils.BitbucketCloud, true, nil, fmt.Sprintf("/repositories/jfrog/repo-1/pullrequests/%v/decline", prId), createBitbucketCloudHandler)
+	defer cleanUp()
+
+	err := client.UpdatePullRequest(ctx, owner, repo1, "PR title", "PR body", "master", prId, vcsutils.Closed)
+	assert.NoError(t, err)
+}
+
 func TestBitbucketCloud_ListOpenPullRequests(t *testing.T) {
 	ctx := context.Background()
 	response, err := os.ReadFile(filepath.Join("testdata", "bitbucketcloud", "pull_requests_list_response.json"))


### PR DESCRIPTION
BB cloud UpdatePullRequest api works a bit different and needs a dedicated api in order to close PRs.
This is required for BB cloud integration tests coverage https://github.com/jfrog/frogbot/pull/1421

- [ ] All [tests](https://github.com/jfrog/froggit-go/actions/workflows/test.yml) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] I used `go fmt ./...` for formatting the code before submitting the pull request.
- [ ] This feature is included on all supported VCS providers - GitHub, Bitbucket cloud, Bitbucket server, GitLab and Azure Repos.
- [ ] I added the relevant documentation for the new feature.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Closing a pull request in Bitbucket Cloud now updates its metadata before applying the platform’s dedicated decline action, ensuring both changes are processed correctly.

* **Tests**
  * Added coverage confirming that closing a pull request sends the metadata update request before the decline request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->